### PR TITLE
Warning fixed

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -237,8 +237,6 @@ module Benchmark
 
       measured_us = measurements.inject(0) { |a,i| a + i }
 
-      seconds = measured_us.to_f / 1_000_000.0
-
       all_ips = measurements.map { |i| cycles_per_100ms.to_f / (i.to_f / 1_000_000) }
 
       avg_ips = Timing.mean(all_ips)


### PR DESCRIPTION
Removed Unused Variable

Got these warnings when running Rails test cases 

``` ruby


/Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/benchmark-ips-1.2.0/lib/benchmark/ips.rb:240: warning: assigned but unused variable - seconds
/Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/benchmark-ips-1.2.0/lib/benchmark/ips.rb:240: warning: assigned but unused variable - seconds
../Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/benchmark-ips-1.2.0/lib/benchmark/ips.rb:240: warning: assigned but unused variable - seconds
/Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/benchmark-ips-1.2.0/lib/benchmark/ips.rb:240: warning: assigned but unused variable - seconds
./Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/benchmark-ips-1.2.0/lib/benchmark/ips.rb:240: warning: assigned but unused variable - seconds
./Users/arunagw/checkouts/rails/bundle/ruby/1.9.1/gems/benchmark-ips-1.2.0/lib/benchmark/ips.rb:240: warning: assigned but unused variable - seconds



```
