### PR TITLE
Update README.md, follow up of c18b452. [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ After checking out the source, run:
 This task will install any missing dependencies, run the tests/specs,
 and generate the RDoc.
 
-Run the example file `bin/benchmark_ips` to test that everything is working properly.
-
 ## LICENSE:
 
 (The MIT License)


### PR DESCRIPTION
`bin/benchmark_ips` has been removed in commit c18b452.
