### PR TITLE
Show time/warmup defaults in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ require 'benchmark/ips'
 
 Benchmark.ips do |x|
   # Configure the number of seconds used during
-  # the warmup phase and calculation phase
+  # the warmup phase (default 2) and calculation phase (default 5)
   x.config(:time => 5, :warmup => 2)
 
   # These parameters can also be configured this way


### PR DESCRIPTION
I wasn't sure if I had to set those each time, or if there were defaults until I went digging through the source. Maybe this might help others mayhaps.
