### PR TITLE
Remove lib/benchmark/helpers.rb from Manifest file.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -4,7 +4,6 @@ Manifest.txt
 README.md
 Rakefile
 lib/benchmark/compare.rb
-lib/benchmark/helpers.rb
 lib/benchmark/ips.rb
 lib/benchmark/ips/report.rb
 lib/benchmark/ips/job.rb


### PR DESCRIPTION
This file has already been removed from https://github.com/JuanitoFatas/benchmark-ips/commit/bc44856d5145fdebe9e07b9dbb4bc27cfacb0f6a.

`rake gem` now results in:

```
rake aborted!
Don't know how to build task 'lib/benchmark/helpers.rb'

Tasks: TOP => gem => pkg/benchmark-ips-2.0.1.gem
(See full trace by running task with --trace)
```

This commit fixes it. Sorry I forget to remove it from `Manifest.txt`.
