### PR TITLE
Fixed broken gemspec

### DIFF
--- a/benchmark-ips.gemspec
+++ b/benchmark-ips.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.description = "A iterations per second enhancement to Benchmark."
   s.email = ["evan@phx.io"]
   s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.md"]
-  s.files = [".autotest", ".gemtest", "History.txt", "Manifest.txt", "README.md", "Rakefile", "lib/benchmark/compare.rb", "lib/benchmark/ips.rb", "lib/benchmark/ips/job.rb", "lib/benchmark/ips/report.rb", "lib/benchmark/timing.rb", "test/test_benchmark_ips.rb"]
+  s.files = [".autotest", "History.txt", "Manifest.txt", "README.md", "Rakefile", "lib/benchmark/compare.rb", "lib/benchmark/ips.rb", "lib/benchmark/ips/job.rb", "lib/benchmark/ips/report.rb", "lib/benchmark/timing.rb", "test/test_benchmark_ips.rb"]
   s.homepage = "https://github.com/evanphx/benchmark-ips"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.md"]


### PR DESCRIPTION
`.gemtest` doesn't exist:

```
$ gem build benchmark-ips.gemspec
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    [".gemtest"] are not files
```