### PR TITLE
Accept symbol as report's argument.

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -13,11 +13,11 @@ module Benchmark
       # Entries in Benchmark Jobs.
       class Entry
         # Instantiate the Benchmark::IPS::Job::Entry.
-        # @param label [String] Label of Benchmarked code.
+        # @param label [#to_s] Label of Benchmarked code.
         # @param action [String, Proc] Code to be benchmarked.
         # @raise [ArgumentError] Raises when action is not String or not responding to +call+.
         def initialize(label, action)
-          @label = label
+          @label = label.to_s
 
           if action.kind_of? String
             compile action

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -10,14 +10,14 @@ module Benchmark
       # Represents benchmarking code data for Report.
       class Entry
         # Instantiate the Benchmark::IPS::Report::Entry.
-        # @param [String] label Label of entry.
+        # @param [#to_s] label Label of entry.
         # @param [Integer] us Measured time in microsecond.
         # @param [Integer] iters Iterations.
         # @param [Float] ips Iterations per second.
         # @param [Float] ips_sd Standard deviation of iterations per second.
         # @param [Integer] cycles Number of Cycles.
         def initialize(label, us, iters, ips, ips_sd, cycles)
-          @label = label
+          @label = label.to_s
           @microseconds = us
           @iterations = iters
           @ips = ips

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -69,4 +69,16 @@ class TestBenchmarkIPS < Minitest::Test
     assert_equal 4*5, rep.iterations
     assert_in_delta 4.0, rep.ips, 0.2
   end
+
+  def test_ips_report_using_symbol
+    report = Benchmark.ips do |x|
+      x.report(:sleep_a_quarter_second) { sleep(0.25) }
+    end
+
+    rep = report.entries.first
+
+    assert_equal "sleep_a_quarter_second", rep.label
+    assert_equal 4*5, rep.iterations
+    assert_in_delta 4.0, rep.ips, 0.2
+  end
 end


### PR DESCRIPTION
Now we could pass symbol to `#report` like the following :blush: :

```ruby
require 'benchmark/ips'

data = [*0..100_000_000]

Benchmark.ips do |x|
  x.report(:find)    { data.find    { |number| number > 77_777_777 } }
  x.report(:bsearch) { data.bsearch { |number| number > 77_777_777 } }
end
```