### PR TITLE
Make block arguments optional

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -21,7 +21,7 @@ module Benchmark
     # @param time [Integer] Specify how long should benchmark your code in seconds.
     # @param warmup [Integer] Specify how long should Warmup time run in seconds.
     # @return [Report]
-    def ips(time=nil, warmup=nil)
+    def ips(time=nil, warmup=nil, &block)
       suite = nil
 
       sync, $stdout.sync = $stdout.sync, true
@@ -42,7 +42,7 @@ module Benchmark
 
       job.config job_opts
 
-      yield job
+      job.instance_eval(&block)
 
       $stdout.puts "Calculating -------------------------------------" unless quiet
 


### PR DESCRIPTION
```ruby
Benchmark.ips do |bm|
  bm.report 'Fast' do
    ...
  end

  bm.report 'Slow' do
    ...
  end

  bm.compare!
end
```
&darr;
```ruby
Benchmark.ips do
  report 'Fast' do
    ...
  end

  report 'Slow' do
    ...
  end

  compare!
end
```
Less typing, easier on the eyes, backwards compatible.