### PR TITLE
Silent a job if a suite was passed and is quiet

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -30,7 +30,7 @@ module Benchmark
         suite = Benchmark::Suite.current
       end
 
-      quiet = suite && !suite.quiet?
+      quiet = suite && suite.quiet?
 
       job = Job.new({:suite => suite,
                      :quiet => quiet


### PR DESCRIPTION
Before this commit the opposite was the case which seems confusing.

The repro:

```ruby
require 'benchmark/ips'

class Benchmark::Suite
  def self.current
    new
  end

  def warming(*)
    run_gc
  end

  def running(*)
    run_gc
  end

  def warmup_stats(*)
  end

  def add_report(*)
  end

  def quiet?
    false
  end

  private

  def run_gc
    GC.enable
    GC.start
    GC.disable
  end
end

Benchmark.ips(1, 1) do |x|
  x.report("gc free") {}
end
```

## Before this PR

(Note the silence although `quiet?` is `false`)

## After this PR

```
Calculating -------------------------------------
             gc free   122.380k i/100ms
-------------------------------------------------
             gc free      6.301M (± 1.8%) i/s -      6.364M
```