### PR TITLE
Allow passing a custom suite via config

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -142,6 +142,7 @@ module Benchmark
       def config opts
         @warmup = opts[:warmup] if opts[:warmup]
         @time = opts[:time] if opts[:time]
+        @suite = opts[:suite] if opts[:suite]
       end
 
       # Return true if job needs to be compared.

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -58,6 +58,21 @@ class TestBenchmarkIPS < Minitest::Test
     assert_in_delta 4.0, rep.ips, 0.2
   end
 
+  def test_ips_config_suite
+    suite = Struct.new(:calls) do
+      def method_missing(method, *args)
+        calls << method
+      end
+    end.new([])
+
+    Benchmark.ips(0.1, 0.1) do |x|
+      x.config(:suite => suite)
+      x.report("job") {}
+    end
+
+    assert_equal [:warming, :warmup_stats, :running, :add_report], suite.calls
+  end
+
   def test_ips_defaults
     report = Benchmark.ips do |x|
       x.report("sleep 0.25") { sleep(0.25) }


### PR DESCRIPTION
For ROM we'd like to disable GC during benchmarks: https://github.com/rom-rb/rom/blob/9ad85095d5fe1b15fd7880899995cd4aadc95197/benchmarks/setup.rb#L56,#L91

After discovering `suite` in `Benchmark::IPS` I wondered if I could pass a suite instance easier.
Defining a `Benchmark::Suite` class which "magically" will be used feels strange to me.

With this PR I'm proposing to pass a suite instance via config like:

```ruby
require 'benchmark/ips'

class GCSuite
  def warming(*)
    run_gc
  end

  def running(*)
    run_gc
  end

  def warmup_stats(*)
  end

  def add_report(*)
  end

  private

  def run_gc
    GC.enable
    GC.start
    GC.disable
  end
end

suite = GCSuite.new 

Benchmark.ips do |x|
  x.config(:suite => suite)
  x.report("job1") { ... }
  x.report("job2") { ... }
end
```

*Update: Suite exmaple completed*