### PR TITLE
Quiet mode

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -21,7 +21,7 @@ module Benchmark
     # @param time [Integer] Specify how long should benchmark your code in seconds.
     # @param warmup [Integer] Specify how long should Warmup time run in seconds.
     # @return [Report]
-    def ips(time=nil, warmup=nil)
+    def ips(time=nil, warmup=nil, quiet=false)
       suite = nil
 
       sync, $stdout.sync = $stdout.sync, true
@@ -30,7 +30,7 @@ module Benchmark
         suite = Benchmark::Suite.current
       end
 
-      quiet = suite && suite.quiet?
+      quiet ||= (suite && suite.quiet?)
 
       job = Job.new({:suite => suite,
                      :quiet => quiet

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -12,6 +12,22 @@ class TestBenchmarkIPS < Minitest::Test
     $stdout = @old_stdout
   end
 
+  def test_output
+    Benchmark.ips(1) do |x|
+      x.report("operation") { 100 * 100 }
+    end
+
+    assert $stdout.string.size > 0
+  end
+
+  def test_quiet
+    Benchmark.ips(1, nil, true) do |x|
+      x.report("operation") { 100 * 100 }
+    end
+
+    assert $stdout.string.size.zero?
+  end
+
   def test_ips
     report = Benchmark.ips do |x|
       x.config(:time => 1, :warmup => 1)


### PR DESCRIPTION
With the `quite` keyword argument we can disable the output.

This feature is quite needed for [ruby-bench](https://github.com/ruby-bench/) and Rails: https://github.com/ruby-bench/ruby-bench-suite/pull/8/files#diff-9c2f5a1dd03f27a99f4330ee96d77d1fR81