### PR TITLE
Remove ree and 1.8.7 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.1.2
-  - ree
   - ruby-head


### PR DESCRIPTION
* they make travis fail and are not supported anymore anyway

I just made it a PR because it's so easy - your call of course (could also be allowed failures) but I think their life time has ended for such a long time so it's cool to get rid of them.