### PR TITLE
Support keyword arguments (1.8 friendly)

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -21,7 +21,13 @@ module Benchmark
     # @param time [Integer] Specify how long should benchmark your code in seconds.
     # @param warmup [Integer] Specify how long should Warmup time run in seconds.
     # @return [Report]
-    def ips(time=nil, warmup=nil, quiet=false)
+    def ips(*args)
+      if args[0].is_a?(Hash)
+        time, warmup, quiet = args[0].values_at(:time, :warmup, :quiet)
+      else
+        time, warmup, quiet = args
+      end
+
       suite = nil
 
       sync, $stdout.sync = $stdout.sync, true

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -12,6 +12,14 @@ class TestBenchmarkIPS < Minitest::Test
     $stdout = @old_stdout
   end
 
+  def test_kwargs
+    Benchmark.ips(:time => 1, :warmup => 1, :quiet => false) do |x|
+      x.report("sleep 0.25") { sleep(0.25) }
+    end
+
+    assert $stdout.string.size > 0
+  end
+
   def test_output
     Benchmark.ips(1) do |x|
       x.report("operation") { 100 * 100 }
@@ -22,6 +30,12 @@ class TestBenchmarkIPS < Minitest::Test
 
   def test_quiet
     Benchmark.ips(1, nil, true) do |x|
+      x.report("operation") { 100 * 100 }
+    end
+
+    assert $stdout.string.size.zero?
+
+    Benchmark.ips(:quiet => true) do |x|
       x.report("operation") { 100 * 100 }
     end
 


### PR DESCRIPTION
This is basically #38 but with ruby 1.8 syntax
Good idea

Fixes #38

I can rebase after you merge #40 or #42 - it needs those to pass