### PR TITLE
Newer Travis for 1.8.7, ree, and 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 1.8.7
   - 1.9.2
@@ -6,5 +7,6 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.1.2
+  - 2.2.2
   - ree
   - ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 gem 'hoe'
 
 gem 'minitest', :group => :test
+
+if RUBY_VERSION < "1.9"
+  gem 'json'
+end


### PR DESCRIPTION
I'd like to see this green

- use newer travis engine
- add tests for 2.2.2
- include json gem for 1.8.7

1. I can split into multiple PRs if you want.
2. You want to drop 1.9.2 or 2.1.0 since this includes 1.9.3 and 2.1.2?

Fixes #40
