### PR TITLE
allow any datatype for labels

### DIFF
--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -19,7 +19,7 @@ Benchmark.ips do |x|
   # and the block must run the code the specific number of times.
   # Used for when the workload is very small and any overhead
   # introduces incorrectable errors.
-  x.report("addition2") do |times|
+  x.report(:addition2) do |times|
     i = 0
     while i < times
       1 + 2

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -53,7 +53,7 @@ module Benchmark
       end
 
       sorted.each do |report|
-        name = report.label
+        name = report.label.to_s
 
         if iter
           x = (best.ips.to_f / report.ips.to_f)

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -17,7 +17,7 @@ module Benchmark
         # @param action [String, Proc] Code to be benchmarked.
         # @raise [ArgumentError] Raises when action is not String or not responding to +call+.
         def initialize(label, action)
-          @label = label.to_s
+          @label = label
 
           if action.kind_of? String
             compile action
@@ -41,7 +41,7 @@ module Benchmark
         end
 
         # The label of benchmarking action.
-        # @return [String] Label of action.
+        # @return [#to_s] Label of action.
         attr_reader :label
 
         # The benchmarking action.
@@ -52,10 +52,11 @@ module Benchmark
         # Otherwise add a new line and 20 whitespaces.
         # @return [String] Right justified label.
         def label_rjust
-          if @label.size > 20
-            "#{@label}\n#{' ' * 20}"
+          label = @label.to_s
+          if label.size > 20
+            "#{label}\n#{' ' * 20}"
           else
-            @label.rjust(20)
+            label.rjust(20)
           end
         end
 

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -17,7 +17,7 @@ module Benchmark
         # @param [Float] ips_sd Standard deviation of iterations per second.
         # @param [Integer] cycles Number of Cycles.
         def initialize(label, us, iters, ips, ips_sd, cycles)
-          @label = label.to_s
+          @label = label
           @microseconds = us
           @iterations = iters
           @ips = ips
@@ -100,7 +100,7 @@ module Benchmark
         # Return header with padding if +@label+ is < length of 20.
         # @return [String] Right justified header (+@label+).
         def header
-          @label.rjust(20)
+          @label.to_s.rjust(20)
         end
 
         # Return string repesentation of Entry object.

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -108,7 +108,7 @@ class TestBenchmarkIPS < Minitest::Test
 
     rep = report.entries.first
 
-    assert_equal "sleep_a_quarter_second", rep.label
+    assert_equal :sleep_a_quarter_second, rep.label
     assert_equal 4*5, rep.iterations
     assert_in_delta 4.0, rep.ips, 0.2
   end


### PR DESCRIPTION
When paired with json, this allows more rich metadata.

I'm having trouble coming up with descriptive labels that I want to use.
So I'm passing in a hash. the hash is being passed through to the json output