### PR TITLE
use runtime if ips is not available

### DIFF
--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -59,7 +59,7 @@ module Benchmark
           x = (best.ips.to_f / report.ips.to_f)
           $stdout.printf "%20s: %10.1f i/s - %.2fx slower\n", name, report.ips, x
         else
-          x = "%.2f" % (report.ips.to_f / best.ips.to_f)
+          x = "%.2f" % ((report.runtime.to_f - best.runtime.to_f) / best.runtime.to_f)
           $stdout.puts "#{name.rjust(20)}: #{report.runtime}s - #{x}x slower"
         end
       end


### PR DESCRIPTION
I think `iter` means that `ips` is not available, and `runtime` should be used instead.

I'd like to write specs around this and wanted to make sure I understood the purpose of `iter`

`Benchmark::Compare#compare` is called with `@entries` by `IPS`.
It looks like `@entries` comes from `add_entry`, which populates `ips` but not `runtime`.

1. Are you thinking about having compare support entries with either `ips`, `ips_sd` OR `runtime`?

2. Seems the gem is focused on a) determining the iteration values, b) timing, c) comparing, and d) reporting - but in theory any of those could be swapped out. E.g.: the timing could be from ruby-prof or even an explain plan from psql.

  Is this close to your thought path / of interest?

3. I was also thinking about moving more towards `printf` in this method with `%20s` rather than the `puts` and `printf` mix. Thoughts?
