### PR TITLE
Don't calculate mean 2 times

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -213,7 +213,7 @@ module Benchmark
           }
 
           avg_ips = Timing.mean(all_ips)
-          sd_ips =  Timing.stddev(all_ips).round
+          sd_ips =  Timing.stddev(all_ips, avg_ips).round
 
           rep = create_report(item, measured_us, iter, avg_ips, sd_ips, cycles)
 


### PR DESCRIPTION
For Job#run, since we just calculated means, pass it into [stddev]

`m` is passed from stddev into `variance` and then it is calculated if not available.
Since we just calculated mean, pass it in.

[stddev]: https://github.com/evanphx/benchmark-ips/blob/edb15d7329f2a1b920079d80d56dbf1e47bce7d7/lib/benchmark/timing.rb#L17