### PR TITLE
Fix runtime comparison

### DIFF
--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -49,7 +49,7 @@ module Benchmark
       if iter
         $stdout.printf "%20s: %10.1f i/s\n", best.label, best.ips
       else
-        $stdout.puts "#{best.rjust(20)}: #{best.runtime}s"
+        $stdout.printf "%20s: #{best.runtime}s\n", best.label
       end
 
       sorted.each do |report|


### PR DESCRIPTION
I kept getting an

    undefined method `rjust' for
    #<Benchmark::IPS::Report::Entry:0x007ff53b8a2950> (NoMethodError)

Makes me wonder if this code is even used by anyone?