### PR TITLE
More understandable ips comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Calculating -------------------------------------
            addition3    83.079k i/100ms
 addition-test-long-label
                         70.129k i/100ms
--------------------------------------------------
+Calculating -------------------------------------
             addition     4.955M (± 8.7%) i/s -     24.155M
            addition2    24.011M (± 9.5%) i/s -    114.246M
            addition3    23.958M (±10.1%) i/s -    115.064M
@@ -78,9 +78,9 @@ addition-test-long-label
 
 Comparison:
            addition2: 24011974.8 i/s
-           addition3: 23958619.8 i/s - 1.00x slower
-addition-test-long-label:  5014756.0 i/s - 4.79x slower
-            addition:  4955278.9 i/s - 4.85x slower
+           addition3: 23958619.8 i/s - 0.00x slower
+addition-test-long-label:  5014756.0 i/s - 0.79x slower
+            addition:  4955278.9 i/s - 0.79x slower
 ```
 
 Benchmark/ips will report the number of iterations per second for a given block

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -43,7 +43,7 @@ module Benchmark
       sorted.each do |report|
         name = report.label.to_s
 
-        x = (best.ips.to_f / report.ips.to_f)
+        x = (best.ips - report.ips) / best.ips.to_f
         $stdout.printf "%20s: %10.1f i/s - %.2fx slower\n", name, report.ips, x
       end
 

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -15,13 +15,13 @@ module Benchmark
   #   Calculating -------------------------------------
   #       Reduce using tag     19216 i/100ms
   #   Reduce using to_proc     17437 i/100ms
-  #   -------------------------------------------------
+  #   Calculating -------------------------------------
   #       Reduce using tag   278950.0 (±8.5%) i/s -    1402768 in   5.065112s
   #   Reduce using to_proc   247295.4 (±8.0%) i/s -    1238027 in   5.037299s
   #
   #   Comparison:
   #       Reduce using tag:   278950.0 i/s
-  #   Reduce using to_proc:   247295.4 i/s - 1.13x slower
+  #   Reduce using to_proc:   247295.4 i/s - 0.11x slower
   #
   # Besides regular Calculating report, this will also indicates which one is slower.
   module Compare


### PR DESCRIPTION
When two pieces of code run the same number of iterations in the same amount of time, that shouldn't be reported as one being "1.00x slower" than the other. By comparing all slower results against the fastest result, and not the other way around, we get some more realistic reporting.