### PR TITLE
Add support for hold! and independent invocations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,29 @@ Benchmark.ips do |x|
 end
 ```
 
+### Independent benchmarking
+
+If you are comparing multiple implementations of a piece of code you may want
+to benchmark them in separate invocations of Ruby so that the measurements
+are independent of each other. You can do this with the `hold!` command.
+
+```ruby
+Benchmark.ips do |x|
+  
+  ...
+  
+  # Hold results between multiple invocations of Ruby
+  x.hold!
+  
+end
+```
+
+This will run only one benchmarks each time you run the command, storing
+results in files in the current directory between invocations. These files are
+named with the hash of benchmark file so will be invalidated if the benchmark
+is changed, but you'll need to manually delete them if you change other files
+between invocations.
+
 ## REQUIREMENTS:
 
 * None!

--- a/README.md
+++ b/README.md
@@ -148,16 +148,14 @@ Benchmark.ips do |x|
   ...
   
   # Hold results between multiple invocations of Ruby
-  x.hold!
+  x.hold! 'filename'
   
 end
 ```
 
 This will run only one benchmarks each time you run the command, storing
-results in files in the current directory between invocations. These files are
-named with the hash of benchmark file so will be invalidated if the benchmark
-is changed, but you'll need to manually delete them if you change other files
-between invocations.
+results in the specified file. The file is deleted when all results have been
+gathered and the report is shown.
 
 ## REQUIREMENTS:
 

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -23,7 +23,7 @@ module Benchmark
     # @param time [Integer] Specify how long should benchmark your code in seconds.
     # @param warmup [Integer] Specify how long should Warmup time run in seconds.
     # @return [Report]
-    def ips(*args)
+    def ips(*args, &block)
       if args[0].is_a?(Hash)
         time, warmup, quiet = args[0].values_at(:time, :warmup, :quiet)
       else
@@ -50,7 +50,12 @@ module Benchmark
 
       job.config job_opts
 
-      yield job
+      block.call job
+      
+      if job.hold?
+        require 'digest/sha1'
+        job.source_hash = Digest::SHA1.hexdigest(File.read(block.source_location.first))[0..12]
+      end
 
       job.run_warmup
       job.run

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -23,7 +23,7 @@ module Benchmark
     # @param time [Integer] Specify how long should benchmark your code in seconds.
     # @param warmup [Integer] Specify how long should Warmup time run in seconds.
     # @return [Report]
-    def ips(*args, &block)
+    def ips(*args)
       if args[0].is_a?(Hash)
         time, warmup, quiet = args[0].values_at(:time, :warmup, :quiet)
       else
@@ -50,12 +50,9 @@ module Benchmark
 
       job.config job_opts
 
-      block.call job
+      yield job
       
-      if job.hold?
-        require 'digest/sha1'
-        job.source_hash = Digest::SHA1.hexdigest(File.read(block.source_location.first))[0..12]
-      end
+      job.load_held_results if job.hold? && job.held_results?
 
       job.run_warmup
       job.run

--- a/lib/benchmark/ips/job/entry.rb
+++ b/lib/benchmark/ips/job/entry.rb
@@ -89,11 +89,11 @@ module Benchmark
           File.open held_filename(job), "w" do |f|
             require "json"
             f.write JSON.pretty_generate({
-              measured_us: measured_us,
-              iter: iter,
-              avg_ips: avg_ips,
-              sd_ips: sd_ips,
-              cycles: cycles
+              :measured_us => measured_us,
+              :iter => iter,
+              :avg_ips => avg_ips,
+              :sd_ips => sd_ips,
+              :cycles => cycles
             })
           end
         end

--- a/lib/benchmark/ips/job/entry.rb
+++ b/lib/benchmark/ips/job/entry.rb
@@ -71,6 +71,32 @@ module Benchmark
           CODE
           m.class_eval code
         end
+        
+        def held_filename(job)
+          @held_filename ||= ".#{label}.#{job.source_hash}.json"
+        end
+        
+        def held_results?(job)
+          File.exist?(held_filename(job))
+        end
+        
+        def held_results(job)
+          require "json"
+          JSON.parse(File.read(held_filename(job)))
+        end
+        
+        def hold_results(job, measured_us, iter, avg_ips, sd_ips, cycles)
+          File.open held_filename(job), "w" do |f|
+            require "json"
+            f.write JSON.pretty_generate({
+              measured_us: measured_us,
+              iter: iter,
+              avg_ips: avg_ips,
+              sd_ips: sd_ips,
+              cycles: cycles
+            })
+          end
+        end
       end
     end
   end

--- a/lib/benchmark/ips/job/entry.rb
+++ b/lib/benchmark/ips/job/entry.rb
@@ -71,32 +71,6 @@ module Benchmark
           CODE
           m.class_eval code
         end
-        
-        def held_filename(job)
-          @held_filename ||= ".#{label}.#{job.source_hash}.json"
-        end
-        
-        def held_results?(job)
-          File.exist?(held_filename(job))
-        end
-        
-        def held_results(job)
-          require "json"
-          JSON.parse(File.read(held_filename(job)))
-        end
-        
-        def hold_results(job, measured_us, iter, avg_ips, sd_ips, cycles)
-          File.open held_filename(job), "w" do |f|
-            require "json"
-            f.write JSON.pretty_generate({
-              :measured_us => measured_us,
-              :iter => iter,
-              :avg_ips => avg_ips,
-              :sd_ips => sd_ips,
-              :cycles => cycles
-            })
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
benchmark-ips is often used to compare different ways to implement the same functionality, but running two benchmarks in the same invocation of Ruby is not going to tell you whether A or B is faster, it's going to tell you if A, or *B-given-that-A-has-already-run* is faster.

For the theory on why this is not ideal, see research such as Kalibera and Jones [1].

For a practical example of why this is not ideal I can illustrate with this benchmark:

```ruby
require 'benchmark/ips'

class Foo
  def method_under_test
    10
  end
end

class Bar
  def method_under_test
    20
  end
end

def call_method_under_test(x)
  x.method_under_test
end

Benchmark.ips do |x|
  
  foo = Foo.new

  x.report("test_a") do
    call_method_under_test foo
  end
  
  bar = Bar.new
  
  x.report("test_b") do
    call_method_under_test bar
  end

  # x.hold! - I'll explain this later on 
  x.compare!
  
end
```

The problem is that in an optimising implementation of Ruby will compile the call `x.method_under_test` as monomorphic for the first benchmark, and bimorphic for the second. The second benchmark is disadvantaged and the results we get for the two benchmarks are dependent on their order.

I can demonstrate this with JRuby+Truffle. I run the benchmark, asking it to only compile the method `call_method_under_test` and turning off splitting and OSR to reduce the noise (otherwise understanding what is being compiled and why is hard).

```
$ JAVACMD=../../graal/GraalVM-0.9/jre/bin/javao bin/jruby -X+T -J-server -J-G:+TraceTruffleCompilation -J-G:TruffleCompileOnly=call_method_under_test -J-G:-TruffleOSR -J-G:-TruffleSplitting -I ../benchmark-ips/lib dependence.rb
```

We see `call_method_under_test` compiled twice, once for each benchmark (it has to be recompiled, as the compiler compiled it with the assumption that it would always be monomorphic baked in, but in some cases the first benchmark keeps the original monomorphic copy and only the second gets the bimorphic one). The first copy is 164 bytes of code, the second is 188. The second benchmark is larger and slower because it came second and so is polymorphic.

```
[truffle] opt done         call_method_under_test:dependence.rb:15 <opt>               |ASTSize      14/   18 |Time   287( 259+28  )ms |DirectCallNodes I    1/D    0 |GraalNodes    35/   28 |CodeSize          164 |Source dependence.rb:15 
[truffle] opt done         call_method_under_test:dependence.rb:15 <opt>               |ASTSize      14/   22 |Time   155( 145+10  )ms |DirectCallNodes I    2/D    0 |GraalNodes    40/   25 |CodeSize          188 |Source dependence.rb:15 
```

My solution to this is to run each benchmark in an independent VM. I added a method `hold!` (like `compare!`) that runs one benchmark, saves the results, and prompts you to run Ruby again for the next benchmark.

```
$ ... bin/jruby -X+T ...
...
[truffle] opt done         call_method_under_test:dependence.rb:15 <opt>               |ASTSize      14/   18 |Time   252( 214+39  )ms |DirectCallNodes I    1/D    0 |GraalNodes    35/   28 |CodeSize          164 |Source dependence.rb:15
...
Pausing here -- run Ruby again to measure the next benchmark...
$ ... bin/jruby -X+T ...
...
[truffle] opt done         call_method_under_test:dependence.rb:15 <opt>               |ASTSize      14/   18 |Time   252( 214+39  )ms |DirectCallNodes I    1/D    0 |GraalNodes    35/   28 |CodeSize          164 |Source dependence.rb:15 
...
```

Now I get two methods, both 164 bytes, and I've so made the benchmarks independent (or a bit more independent).

This is optional - you only need to use it if you want to. It saves data in a little file that is checksummed so it's invalidated if you benchmark changes.

[1] https://kar.kent.ac.uk/33611/7/paper.pdf