### PR TITLE
Tighten timing loop.

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -172,13 +172,13 @@ module Benchmark
 
           iter = 0
 
-          target = Time.now + @time
-
           measurements_us = []
 
           # Running this number of cycles should take around 100ms.
           cycles = @timing[item]
 
+          target = Time.now + @time
+          
           while Time.now < target
             before = Time.now
             item.call_times cycles


### PR DESCRIPTION
The timing loop currently starts the clock, and then creates an array and looks something up in a hash. This patch moves starting the clock until the last possible moment.