### PR TITLE
Add iterations option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ are independent of each other. You can do this with the `hold!` command.
 ```ruby
 Benchmark.ips do |x|
   
-  ...
-  
   # Hold results between multiple invocations of Ruby
   x.hold! 'filename'
   
@@ -156,6 +154,29 @@ end
 This will run only one benchmarks each time you run the command, storing
 results in the specified file. The file is deleted when all results have been
 gathered and the report is shown.
+
+### Multiple iterations
+
+In some cases you may want to run multiple iterations of the warmup and
+calculation stages and take only the last result for comparison. This is useful
+if you are benchmarking with an implementation of Ruby that optimizes using
+tracing or on-stack-replacement, because to those implementations the
+calculation phase may appear as new, unoptimized code.
+
+You can do this with the `iterations` option, which by default is `1`. The
+total time spent will then be `iterations * warmup + iterations * time` seconds.
+
+```ruby
+Benchmark.ips do |x|
+
+  x.config(:iterations => 3)
+
+    # or
+  
+  x.iterations = 3
+  
+end
+```
 
 ## REQUIREMENTS:
 

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -54,7 +54,6 @@ module Benchmark
       
       job.load_held_results if job.hold? && job.held_results?
 
-      job.run_warmup
       job.run
 
       $stdout.sync = sync

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -207,15 +207,15 @@ module Benchmark
         @stdout.start_running if @stdout
         @iterations.times do |n|
           @list.each do |item|
-            @suite.running item.label, @time if @suite
-            @stdout.running item.label, @time if @stdout
-            
             if hold? && @held_results && @held_results.key?(item.label)
              result = @held_results[item.label]
               create_report(item.label, result['measured_us'], result['iter'],
                 result['avg_ips'], result['sd_ips'], result['cycles'])
               next
             end
+            
+            @suite.running item.label, @time if @suite
+            @stdout.running item.label, @time if @stdout
 
             Timing.clean_env
 
@@ -277,8 +277,11 @@ module Benchmark
                 f.write "\n"
               end
               
-              puts
-              puts 'Pausing here -- run Ruby again to measure the next benchmark...'
+              if n == @iterations-1
+                puts
+                puts 'Pausing here -- run Ruby again to measure the next benchmark...'
+              end
+              
               break
             end
           end

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -38,6 +38,10 @@ module Benchmark
       # @return [Integer]
       attr_accessor :time
 
+      # Warmup and calculation iterations.
+      # @return [Integer]
+      attr_accessor :iterations
+
       # Instantiate the Benchmark::IPS::Job.
       # @option opts [Benchmark::Suite] (nil) :suite Specify Benchmark::Suite.
       # @option opts [Boolean] (false) :quiet Suppress the printing of information.
@@ -56,15 +60,18 @@ module Benchmark
         # Default warmup and calculation time in seconds.
         @warmup = 2
         @time = 5
+        @iterations = 1
       end
 
       # Job configuration options, set +@warmup+ and +@time+.
       # @option opts [Integer] :warmup Warmup time.
       # @option opts [Integer] :time Calculation time.
+      # @option iterations [Integer] :time Warmup and calculation iterations.
       def config opts
         @warmup = opts[:warmup] if opts[:warmup]
         @time = opts[:time] if opts[:time]
         @suite = opts[:suite] if opts[:suite]
+        @iterations = opts[:iterations] if opts[:iterations]
       end
 
       # Return true if job needs to be compared.
@@ -162,119 +169,123 @@ module Benchmark
       # Run warmup.
       def run_warmup
         @stdout.start_warming if @stdout
-        @list.each do |item|
-          next if hold? && @held_results && @held_results.key?(item.label)
+        @iterations.times do
+          @list.each do |item|
+            next if hold? && @held_results && @held_results.key?(item.label)
           
-          @suite.warming item.label, @warmup if @suite
-          @stdout.warming item.label, @warmup if @stdout
+            @suite.warming item.label, @warmup if @suite
+            @stdout.warming item.label, @warmup if @stdout
 
-          Timing.clean_env
+            Timing.clean_env
 
-          before = Time.now
-          target = Time.now + @warmup
+            before = Time.now
+            target = Time.now + @warmup
 
-          warmup_iter = 0
+            warmup_iter = 0
 
-          while Time.now < target
-            item.call_times(1)
-            warmup_iter += 1
+            while Time.now < target
+              item.call_times(1)
+              warmup_iter += 1
+            end
+
+            after = Time.now
+
+            warmup_time_us = time_us before, after
+
+            @timing[item] = cycles_per_100ms warmup_time_us, warmup_iter
+
+            @stdout.warmup_stats warmup_time_us, @timing[item] if @stdout
+            @suite.warmup_stats warmup_time_us, @timing[item] if @suite
+          
+            break if hold?
           end
-
-          after = Time.now
-
-          warmup_time_us = time_us before, after
-
-          @timing[item] = cycles_per_100ms warmup_time_us, warmup_iter
-
-          @stdout.warmup_stats warmup_time_us, @timing[item] if @stdout
-          @suite.warmup_stats warmup_time_us, @timing[item] if @suite
-          
-          break if hold?
         end
       end
 
       # Run calculation.
       def run
         @stdout.start_running if @stdout
-        @list.each do |item|
-          if hold? && @held_results && @held_results.key?(item.label)
-           result = @held_results[item.label]
-            create_report(item.label, result['measured_us'], result['iter'],
-              result['avg_ips'], result['sd_ips'], result['cycles'])
-            next
-          end
-          
-          @suite.running item.label, @time if @suite
-          @stdout.running item.label, @time if @stdout
-
-          Timing.clean_env
-
-          iter = 0
-
-          measurements_us = []
-
-          # Running this number of cycles should take around 100ms.
-          cycles = @timing[item]
-
-          target = Time.now + @time
-          
-          while Time.now < target
-            before = Time.now
-            item.call_times cycles
-            after = Time.now
-
-            # If for some reason the timing said this took no time (O_o)
-            # then ignore the iteration entirely and start another.
-            iter_us = time_us before, after
-            next if iter_us <= 0.0
-
-            iter += cycles
-
-            measurements_us << iter_us
-          end
-
-          final_time = Time.now
-
-          measured_us = measurements_us.inject(0) { |a,i| a + i }
-
-          all_ips = measurements_us.map { |time_us|
-            iterations_per_sec cycles, time_us
-          }
-
-          avg_ips = Timing.mean(all_ips)
-          sd_ips =  Timing.stddev(all_ips, avg_ips).round
-
-          rep = create_report(item.label, measured_us, iter, avg_ips, sd_ips, cycles)
-
-          if (final_time - target).abs >= (@time.to_f * MAX_TIME_SKEW)
-            rep.show_total_time!
-          end
-
-          @stdout.add_report rep, caller(1).first if @stdout
-          @suite.add_report rep, caller(1).first if @suite
-          
-          if hold? && item != @list.last
-            File.open @held_path, "a" do |f|
-              require "json"
-              f.write JSON.generate({
-                :item => item.label,
-                :measured_us => measured_us,
-                :iter => iter,
-                :avg_ips => avg_ips,
-                :sd_ips => sd_ips,
-                :cycles => cycles
-              })
-              f.write "\n"
-            end
+        @iterations.times do |n|
+          @list.each do |item|
+            @suite.running item.label, @time if @suite
+            @stdout.running item.label, @time if @stdout
             
-            puts
-            puts 'Pausing here -- run Ruby again to measure the next benchmark...'
-            break
+            if hold? && @held_results && @held_results.key?(item.label)
+             result = @held_results[item.label]
+              create_report(item.label, result['measured_us'], result['iter'],
+                result['avg_ips'], result['sd_ips'], result['cycles'])
+              next
+            end
+
+            Timing.clean_env
+
+            iter = 0
+
+            measurements_us = []
+
+            # Running this number of cycles should take around 100ms.
+            cycles = @timing[item]
+
+            target = Time.now + @time
+            
+            while Time.now < target
+              before = Time.now
+              item.call_times cycles
+              after = Time.now
+
+              # If for some reason the timing said this took no time (O_o)
+              # then ignore the iteration entirely and start another.
+              iter_us = time_us before, after
+              next if iter_us <= 0.0
+
+              iter += cycles
+
+              measurements_us << iter_us
+            end
+
+            final_time = Time.now
+
+            measured_us = measurements_us.inject(0) { |a,i| a + i }
+
+            all_ips = measurements_us.map { |time_us|
+              iterations_per_sec cycles, time_us
+            }
+
+            avg_ips = Timing.mean(all_ips)
+            sd_ips =  Timing.stddev(all_ips, avg_ips).round
+
+            rep = create_report(item.label, measured_us, iter, avg_ips, sd_ips, cycles)
+
+            if (final_time - target).abs >= (@time.to_f * MAX_TIME_SKEW)
+              rep.show_total_time!
+            end
+
+            @stdout.add_report rep, caller(1).first if @stdout
+            @suite.add_report rep, caller(1).first if @suite
+            
+            if hold? && item != @list.last
+              File.open @held_path, "a" do |f|
+                require "json"
+                f.write JSON.generate({
+                  :item => item.label,
+                  :measured_us => measured_us,
+                  :iter => iter,
+                  :avg_ips => avg_ips,
+                  :sd_ips => sd_ips,
+                  :cycles => cycles
+                })
+                f.write "\n"
+              end
+              
+              puts
+              puts 'Pausing here -- run Ruby again to measure the next benchmark...'
+              break
+            end
           end
-        end
-        
-        if hold? && @full_report.entries.size == @list.size
-          File.delete @held_path if File.exist?(@held_path)
+          
+          if hold? && @full_report.entries.size == @list.size
+            File.delete @held_path if File.exist?(@held_path)
+          end
         end
       end
 

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -137,6 +137,7 @@ module Benchmark
       # @return [Report::Entry] Last added entry.
       def add_entry label, microseconds, iters, ips, ips_sd, measurement_cycle
         entry = Entry.new(label, microseconds, iters, ips, ips_sd, measurement_cycle)
+        @entries.delete_if { |e| e.label == label }
         @entries << entry
         entry
       end


### PR DESCRIPTION
Implementations of Ruby that optimize other than at method granularity, such as those using tracing or on-stack-replacement, maybe tripped up by the transition from the warmup phase to the calculation phase. The warmup loop may appear as new code, and if no deeper levels were independently optimized, this may mean that the first thing the benchmark may have to do after the clock starts is to optimize from scratch! And it'll have to do that under the clock, while running the fallback interpreter until the compiler is done.

A similar problem is value profiling. An implementation of Ruby that sees that the value of `times` passed to `call_times` is always `1` during the warmup phase may make the speculative but reasonable assumption that it is always going to be `1`. When we get to the calculation phase and it's suddenly a different number, again the first thing the benchmark may have to do after the clock starts is to throw away code and start optimizing again.

We can demonstrate this problem in JRuby+Truffle, which uses on-stack-replacment and so may optimize the inner loop of the `while` loop in the warmup phase and inline the tested method, rather than compiling the method being tested directly.

I used this benchmark:

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  
  v = 2
  
  x.report("clamp1") do
    [1, v, 3].sort[1]
  end
  
  x.report("clamp2") do
    if v < 1
      1
    elsif v > 3
      3
    else
      v
    end
  end
  
  x.compare!
  
end
```

By default, `clamp1` appears to be a lot slower than `clamp2`, but I know a priori that they should be roughly the same.

```
$ jt run --graal -I ../benchmark-ips/lib ../bips-tests/clamp.rb 
$ JAVACMD=/Users/chrisseaton/Documents/graal/GraalVM-0.9/jre/bin/javao /Users/chrisseaton/Documents/ruby/jruby/bin/jruby -X+T -Xtruffle.core.load_path=/Users/chrisseaton/Documents/ruby/jruby/truffle/src/main/ruby -Xtruffle.graal.warn_unless=false -J-server -I ../benchmark-ips/lib ../bips-tests/clamp.rb
Calculating -------------------------------------
              clamp1   579.000  i/100ms
              clamp2     3.877k i/100ms
Calculating -------------------------------------
              clamp1    553.417k (± 19.0%) i/s -    971.562k
              clamp2      3.835M (± 9.7%) i/s -     11.805M

Comparison:
              clamp2:  3835173.3 i/s
              clamp1:   553417.2 i/s - 6.93x slower
```

If I turn on Truffle's `-G:+TraceTruffleCompilation` option I can see why. The first thing it does when it starts timing is an invalidation (or *uncommon trap* in the blue book terminology).

```
Calculating -------------------------------------
              clamp1[truffle] opt invalidated  entry.rb:52<OSR>
```

`entry.rb:52<OSR>` is that while loop that depends on the number of cycles per 100ms.

One solution (mentioned by @headius) is to run the whole `Benchmark.ips` in a loop.

```ruby
2.times do
  Benchmark.ips do |x|
    ...
  end
end
```

```
$ jt run --graal -I ../benchmark-ips/lib ../bips-tests/clamp-looped.rb 
$ JAVACMD=/Users/chrisseaton/Documents/graal/GraalVM-0.9/jre/bin/javao /Users/chrisseaton/Documents/ruby/jruby/bin/jruby -X+T -Xtruffle.core.load_path=/Users/chrisseaton/Documents/ruby/jruby/truffle/src/main/ruby -Xtruffle.graal.warn_unless=false -J-server -I ../benchmark-ips/lib ../bips-tests/clamp-looped.rb
Calculating -------------------------------------
              clamp1   260.000  i/100ms
              clamp2     2.244k i/100ms
Calculating -------------------------------------
              clamp1    244.792k (± 21.4%) i/s -    429.780k
              clamp2      2.203M (± 12.7%) i/s -      5.610M

Comparison:
              clamp2:  2203253.7 i/s
              clamp1:   244791.6 i/s - 9.00x slower

Calculating -------------------------------------
              clamp1    30.703k i/100ms
              clamp2    35.067k i/100ms
Calculating -------------------------------------
              clamp1     30.684M (± 1.9%) i/s -    140.620M
              clamp2     35.046M (± 1.9%) i/s -    165.166M

Comparison:
              clamp2:  35046139.1 i/s
              clamp1:  30683865.5 i/s - 1.14x slower
```

That helps, but now we get extra output, and there's still a difference between the two.

My solution is to add a new option `iterations`, alongside `warmup` and `time`. It runs both the warmup and time phases in a loop, but then only uses the final results for the comparison. Like running the whole thing in a loop this means that when we measure time the measure loop has been seen before by the VM.

```ruby
  x.iterations = 2
```

```
$ jt run --graal -I ../benchmark-ips/lib ../bips-tests/clamp-iterations.rb 
$ JAVACMD=/Users/chrisseaton/Documents/graal/GraalVM-0.9/jre/bin/javao /Users/chrisseaton/Documents/ruby/jruby/bin/jruby -X+T -Xtruffle.core.load_path=/Users/chrisseaton/Documents/ruby/jruby/truffle/src/main/ruby -Xtruffle.graal.warn_unless=false -J-server -I ../benchmark-ips/lib ../bips-tests/clamp-iterations.rb
Calculating -------------------------------------
              clamp1   525.000  i/100ms
              clamp2     9.306k i/100ms
              clamp1    25.661k i/100ms
              clamp2    28.085k i/100ms
Calculating -------------------------------------
              clamp1     25.553M (± 5.6%) i/s -     99.847M
              clamp2     28.021M (± 4.1%) i/s -    121.973M
              clamp1     25.635M (± 2.5%) i/s -    114.551M
              clamp2     28.066M (± 2.1%) i/s -    131.382M

Comparison:
              clamp2:  28065676.6 i/s
              clamp1:  25634660.7 i/s - 1.09x slower
```

Now the results are more stable, but I don't see tons of extra output - the final actionable summary is still concise.

Note that this *isn't just about warmup time*. I also tried simply doubling the warmup and sampling time, so that the total time is the same as when I use `iterations`, and it doesn't fix it.

```ruby
  x.warmup = 4
  x.time = 10
```

```
$ jt run --graal -I ../benchmark-ips/lib ../bips-tests/clamp-extra-time.rb 
$ JAVACMD=/Users/chrisseaton/Documents/graal/GraalVM-0.9/jre/bin/javao /Users/chrisseaton/Documents/ruby/jruby/bin/jruby -X+T -Xtruffle.core.load_path=/Users/chrisseaton/Documents/ruby/jruby/truffle/src/main/ruby -Xtruffle.graal.warn_unless=false -J-server -I ../benchmark-ips/lib ../bips-tests/clamp-extra-time.rb
Calculating -------------------------------------
              clamp1     6.640k i/100ms
              clamp2    42.616k i/100ms
Calculating -------------------------------------
              clamp1      6.614M (± 5.7%) i/s -     45.537M
              clamp2     42.531M (± 3.6%) i/s -    393.133M

Comparison:
              clamp2:  42531497.9 i/s
              clamp1:  6613508.1 i/s - 6.43x slower
```

`iterations` is set to `1` by default, so there is no difference in time taken or output unless you go out of your way to set it.
