### PR TITLE
use the monotonic clock for getting the current time

### DIFF
--- a/lib/benchmark/timing.rb
+++ b/lib/benchmark/timing.rb
@@ -1,6 +1,8 @@
 module Benchmark
   # Perform caclulations on Timing results.
   module Timing
+    # Microseconds per second.
+    MICROSECONDS_PER_SECOND = 1_000_000
 
     # Calculate (arithmetic) mean of given samples.
     # @param [Array] samples Samples to calculate mean.
@@ -50,6 +52,22 @@ module Benchmark
         GC.run(true)
       else
         GC.start
+      end
+    end
+
+    begin
+      Process.clock_gettime Process::CLOCK_MONOTONIC, :float_microsecond
+
+      # Get a time that represents microseconds from some offset (which is not
+      # necessarily the epoch!!!!)
+      def self.now_us
+        Process.clock_gettime Process::CLOCK_MONOTONIC, :float_microsecond
+      end
+    rescue NameError
+      # Get a time that represents microseconds from some offset (which is not
+      # necessarily the epoch!!!!)
+      def self.now_us
+        Time.now.to_f * 1_0000
       end
     end
   end


### PR DESCRIPTION
This has a few advantages over using Time.now.  First the monotonic
clock will not change even if the system clock changes while the
benchmark is running.  Second, we don't have to coerce Time objects to
floats every time we want to calculate the test runtime.  Third, we
don't have to allocate Time objects on each iteration which /should/
reduce stddev noise from the GC.