### PR TITLE
Remove extra before timer call

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -243,8 +243,7 @@ module Benchmark
 
           target = Timing.add_second Timing.now, @time
           
-          while Timing.now < target
-            before = Timing.now
+          while (before = Timing.now) < target
             item.call_times cycles
             after = Timing.now
 


### PR DESCRIPTION
minor, but it reduces 1 timer call per iteration and the results will be the same.