### PR TITLE
Reduce timer calls 2

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -258,7 +258,7 @@ module Benchmark
             measurements_us << iter_us
           end
 
-          final_time = Timing.now
+          final_time = before
 
           measured_us = measurements_us.inject(0) { |a,i| a + i }
 


### PR DESCRIPTION
This one is less convincing than the last, as it only removes 1 timer call per invocation and reasoning why `before` is used is a little confusing.

I've thought of this for a while, and just wanted to put it out there.

This depends upon #63 (in that PR, before will always be set on every iteration)