### PR TITLE
Add the new share file to the gem files

### DIFF
--- a/benchmark-ips.gemspec
+++ b/benchmark-ips.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.description = "A iterations per second enhancement to Benchmark."
   s.email = ["evan@phx.io"]
   s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.md"]
-  s.files = [".autotest", ".gemtest", "History.txt", "Manifest.txt", "README.md", "Rakefile", "lib/benchmark/compare.rb", "lib/benchmark/ips.rb", "lib/benchmark/ips/job.rb", "lib/benchmark/ips/report.rb", "lib/benchmark/timing.rb", "test/test_benchmark_ips.rb"]
+  s.files = [".autotest", ".gemtest", "History.txt", "Manifest.txt", "README.md", "Rakefile", "lib/benchmark/compare.rb", "lib/benchmark/ips.rb", "lib/benchmark/ips/job.rb", "lib/benchmark/ips/share.rb", "lib/benchmark/ips/report.rb", "lib/benchmark/timing.rb", "test/test_benchmark_ips.rb"]
   s.homepage = "https://github.com/evanphx/benchmark-ips"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.md"]


### PR DESCRIPTION
😢  

```
~/workspace/sandbox » SHARE=1 ruby benchmarktest.rb                                                                                                                                     carcand@carcand-OSX
Warming up --------------------------------------
            addition   319.524k i/100ms
           addition2   324.455k i/100ms
           addition3   440.927k i/100ms
addition-test-long-label
                       318.216k i/100ms
Calculating -------------------------------------
            addition     11.014M (± 1.3%) i/s -     55.278M in   5.019676s
           addition2     39.479M (± 1.2%) i/s -    197.593M in   5.005824s
           addition3     39.667M (± 2.9%) i/s -    198.417M in   5.007460s
addition-test-long-label
                         11.077M (± 2.5%) i/s -     55.370M in   5.001687s

Comparison:
           addition3: 39666718.7 i/s
           addition2: 39479205.4 i/s - same-ish: difference falls within error
addition-test-long-label: 11077377.8 i/s - 3.58x slower
            addition: 11014202.7 i/s - 3.60x slower

/Users/carcand/.rbenv/versions/2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- benchmark/ips/share (LoadError)
        from /Users/carcand/.rbenv/versions/2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /Users/carcand/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/benchmark-ips-2.6.0/lib/benchmark/ips.rb:66:in `ips'
        from benchmarktest.rb:3:in `<main>'
```