### PR TITLE
Configurable sampling frequency/duration

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -59,7 +59,7 @@ module Benchmark
         @held_results = nil
 
         @timing = {}
-        @full_report = Report.new
+        @full_report = Report.new(self)
 
         # Default warmup and calculation time in seconds.
         @warmup = 2

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -2,8 +2,8 @@ module Benchmark
   module IPS
     # Benchmark jobs.
     class Job
-      # Microseconds per 100 millisecond.
-      MICROSECONDS_PER_100MS = 100_000
+      # Default sample duration.
+      DEFAULT_SAMPLE_DURATION = 0.1
       # Microseconds per second.
       MICROSECONDS_PER_SECOND = Timing::MICROSECONDS_PER_SECOND
       # The percentage of the expected runtime to allow
@@ -42,6 +42,10 @@ module Benchmark
       # @return [Integer]
       attr_accessor :iterations
 
+      # Intended sample duration (in seconds).
+      # @return [Float]
+      attr_accessor :sample_duration
+
       # Instantiate the Benchmark::IPS::Job.
       # @option opts [Benchmark::Suite] (nil) :suite Specify Benchmark::Suite.
       # @option opts [Boolean] (false) :quiet Suppress the printing of information.
@@ -61,6 +65,7 @@ module Benchmark
         @warmup = 2
         @time = 5
         @iterations = 1
+        @sample_duration = DEFAULT_SAMPLE_DURATION
       end
 
       # Job configuration options, set +@warmup+ and +@time+.
@@ -72,6 +77,7 @@ module Benchmark
         @time = opts[:time] if opts[:time]
         @suite = opts[:suite] if opts[:suite]
         @iterations = opts[:iterations] if opts[:iterations]
+        @sample_duration = opts[:sample_duration] if opts[:sample_duration]
       end
 
       # Return true if job needs to be compared.
@@ -126,13 +132,15 @@ module Benchmark
       end
       alias_method :report, :item
 
-      # Calculate the cycles needed to run for approx 100ms,
-      # given the number of iterations to run the given time.
+      # Calculate the cycles needed to run for targeted sample duration
+      # (100ms by default), given the number of iterations to run
+      # the given time.
       # @param [Float] time_msec Each iteration's time in ms.
       # @param [Integer] iters Iterations.
-      # @return [Integer] Cycles per 100ms.
-      def cycles_per_100ms time_msec, iters
-        cycles = ((MICROSECONDS_PER_100MS / time_msec) * iters).to_i
+      # @return [Integer] Cycles per sample.
+      def cycles_per_sample time_msec, iters
+        sample_in_msec = @sample_duration * MICROSECONDS_PER_SECOND
+        cycles = ((sample_in_msec / time_msec) * iters).to_i
         cycles = 1 if cycles <= 0
         cycles
       end
@@ -210,7 +218,7 @@ module Benchmark
 
           warmup_time_us = Timing.time_us(before, after)
 
-          @timing[item] = cycles_per_100ms warmup_time_us, warmup_iter
+          @timing[item] = cycles_per_sample warmup_time_us, warmup_iter
 
           @stdout.warmup_stats warmup_time_us, @timing[item] if @stdout
           @suite.warmup_stats warmup_time_us, @timing[item] if @suite

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -122,7 +122,9 @@ module Benchmark
       attr_reader :entries
 
       # Instantiate the Report.
-      def initialize
+      # @param job [Job] This report's Job.
+      def initialize(job)
+        @job = job
         @entries = []
         @data = nil
       end
@@ -166,7 +168,7 @@ module Benchmark
 
       # Run comparison of entries.
       def run_comparison
-        Benchmark.compare(*@entries)
+        Benchmark.compare(@job, *@entries)
       end
 
       # Generate json from Report#data to given path.


### PR DESCRIPTION
Grrrr, alright, I've had enough :cry: :rage: :neckbeard:.

Don't know if I'm going to be able to get this merged, but lets at least try (I'm open to all kinds of suggestions and will amend the PR as necessary).

Here's the deal: `benchmark-ips` has been immensely beneficial to the state of accurate Ruby benchmarking, however I feel that in some cases it does lead its users astray. Namely because it measures and reports SD and newly (#60) rightfully refuses to decide benchmarks on flimsy statistical evidence, this leads some developers to inaccurately conclude that 2 versions of the code being benchmarked are equal in performance, when in fact this is demonstrably false. It is not that the benchmark is undecidable, it is just their configuration of `benchmark-ips` that prevents them from arriving to the correct result.

In my experience (subjective anecdotal evidence for the win :innocent:), in the absence of hard time limits on benchmark duration, it is absolutely the case that noisy benchmarks **can be** tamed and decided. Ignoring variance while benchmarking is of course a fools errand, but sometimes some noise is acceptable and we want to know which version of the code is faster (it is also usually the case that both versions have comparable SD, so it is not about plunging for the average while ignoring the latency/SD).

In this PR I propose to make sample duration/interval (or in other words sampling frequency) configurable, additionally in case of statistically ambiguous results, `benchmark-ips` would now propose to the user to tweak the configuration and attempt to re-run the experiment with a longer duration and decreased sampling frequency.

The PR is a spiritual successor to @chrisseaton's PR #60, let me know what you guys think.

------

Tested with MRI:

```ruby
# bench.rb
require 'benchmark/ips'

# I like to make my VMs work instead of sleeping ;)
def work(num)
  nnum = num * 300 # magic const to make the example work
  i = 0
  while i < nnum
    i+=1
  end
  i
end

Benchmark.ips do |x|
  x.report("work(1000 + r(500))") do
    work(1000 + rand(500))
  end

  x.report("work(1000 + r(400))") do
    work(1000 + rand(400))
  end

  x.compare!
end
```

```
> ruby -Ilib bench.rb ⏎
Warming up --------------------------------------
 work(1000 + r(500))    15.000  i/100ms
 work(1000 + r(400))    15.000  i/100ms
Calculating -------------------------------------
 work(1000 + r(500))    155.226  (± 2.6%) i/s -    780.000  in   5.029015s
 work(1000 + r(400))    162.102  (± 3.1%) i/s -    810.000  in   5.000809s

Comparison:
 work(1000 + r(400)):      162.1 i/s
 work(1000 + r(500)):      155.2 i/s - same-ish: difference falls within error

-------------------------------------------------------------------------

Some reports were within standard deviation of each other. Because of that
benchmark-ips was unable to decide which of them is faster. It is quite
possible that with a slightly tweaked configuration benchmark-ips will
be able to provide more accurate results.

Please try re-running your benchmark with the following additional
configuration:

  Benchmark.ips do |x|
    x.sample_duration = 0.4 # <--- new config
    x.time = 10 # <--- new config
    # ...

Please note that running the benchmark with the new configuration
will take longer and might not result in a more accurate measurement.
In that case benchmark-ips will re-print this warning with an even
more aggressive configuration option suggestions. It is a good idea
to try to follow benchmark-ips's advice a couple of times (each time
re-running the benchmark with new options), letting it escalate
its configuration repeatedly (a good rule is to give up after 3-4
iterations).
```

Implement suggested changes:

```ruby
# bench.rb
require 'benchmark/ips'

# I like to make my VMs work instead of sleeping ;)
def work(num)
  nnum = num * 300 # magic const to make the example work
  i = 0
  while i < nnum
    i+=1
  end
  i
end

Benchmark.ips do |x|
  x.sample_duration = 0.4
  x.time = 10
  
  x.report("work(1000 + r(500))") do
    work(1000 + rand(500))
  end

  x.report("work(1000 + r(400))") do
    work(1000 + rand(400))
  end

  x.compare!
end
```

```
> ruby -Ilib bench.rb ⏎
Warming up --------------------------------------
 work(1000 + r(500))    61.000  i/100ms
 work(1000 + r(400))    64.000  i/100ms
Calculating -------------------------------------
 work(1000 + r(500))    154.372  (± 1.3%) i/s -      1.586k in  10.276211s
 work(1000 + r(400))    161.165  (± 1.2%) i/s -      1.664k in  10.326133s

Comparison:
 work(1000 + r(400)):      161.2 i/s
 work(1000 + r(500)):      154.4 i/s - 1.04x slower
```
✨ 🎉 