### PR TITLE
Add support for confidence intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,14 +193,23 @@ can be calculated instead. A bootstrap confidence interval has the advantages of
 arguably being more mathematically sound for this application than a standard
 deviation, it additionally produces an error for relative slowdowns, which the
 standard deviation does not, and it is arguably more intuitive and actionable.
-W
-hen a bootstrap confidence interval is used, a median of the interval is used
+
+When a bootstrap confidence interval is used, a median of the interval is used
 rather than the mean of the samples, which is what you get with the default
 standard deviation.
+
+The bootstrap confidence interval used is the one described by Tomas Kalibera.
+Note that for this technique to be valid your benchmark should have reached a
+non-periodic steady state with statistically independent samples (it should
+have warmed up) by the time measurements start.
 
 Using a bootstrap confidence internal requires that the 'kalibera' gem is
 installed separately. This gem is not a formal dependency, as by default it is
 not needed.
+
+```
+gem install kalibera
+```
 
 ```ruby
 Benchmark.ips do |x|

--- a/README.md
+++ b/README.md
@@ -185,6 +185,38 @@ with `SHARE=1` argument. I.e.: `SHARE=1 ruby my_benchmark.rb`.
 Result will be sent to [benchmark.fyi](https://benchmark.fyi/) and benchmark-ips
 will display the link to share the benchmark's result.
 
+### Advanced Statistics
+
+By default, the margin of error shown is plus-minus one standard deviation. If
+a more advanced statistical test is wanted, a bootstrap confidence interval
+can be calculated instead. A bootstrap confidence interval has the advantages of
+arguably being more mathematically sound for this application than a standard
+deviation, it additionally produces an error for relative slowdowns, which the
+standard deviation does not, and it is arguably more intuitive and actionable.
+W
+hen a bootstrap confidence interval is used, a median of the interval is used
+rather than the mean of the samples, which is what you get with the default
+standard deviation.
+
+Using a bootstrap confidence internal requires that the 'kalibera' gem is
+installed separately. This gem is not a formal dependency, as by default it is
+not needed.
+
+```ruby
+Benchmark.ips do |x|
+
+  # The default is :stats => :sd, which doesn't have a configurable confidence
+  x.config(:stats => :bootstrap, :confidence => 95)
+
+    # or
+
+  x.stats = :bootstrap
+  x.confidence = 95
+  
+  # confidence is 95% by default, so it can be omitted
+
+end
+```
 
 ## REQUIREMENTS:
 

--- a/examples/advanced.rb
+++ b/examples/advanced.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+
+  # Use bootstrap confidence intervals
+  x.stats = :bootstrap
+
+  # Set confidence to 95%
+  x.confidence = 95
+
+  # Run multiple iterations for better warmup
+  x.iterations = 3
+
+  x.report("mul") { 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 }
+  x.report("pow") { 2 ** 8 }
+
+  x.compare!
+end

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -63,6 +63,9 @@ module Benchmark
         $stdout.puts
       end
 
+      footer = best.stats.footer
+      $stdout.puts footer.rjust(40) if footer
+
       $stdout.puts
     end
   end

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -32,27 +32,27 @@ module Benchmark
     def compare(*entries)
       return if entries.size < 2
 
-      sorted = entries.sort_by(&:ips).reverse
+      sorted = entries.sort_by{ |e| e.stats.central_tendency }.reverse
 
       best = sorted.shift
 
       $stdout.puts "\nComparison:"
 
-      $stdout.printf "%20s: %10.1f i/s\n", best.label, best.ips
+      $stdout.printf "%20s: %10.1f i/s\n", best.label, best.stats.central_tendency
 
       sorted.each do |report|
         name = report.label.to_s
         
-        $stdout.printf "%20s: %10.1f i/s - ", name, report.ips
+        $stdout.printf "%20s: %10.1f i/s - ", name, report.stats.central_tendency
         
-        best_low = best.ips - best.ips_sd
-        report_high = report.ips + report.ips_sd
+        best_low = best.stats.central_tendency - best.stats.error
+        report_high = report.stats.central_tendency + report.stats.error
         overlaps = report_high > best_low 
         
         if overlaps
           $stdout.print "same-ish: difference falls within error"
         else
-          x = (best.ips.to_f / report.ips.to_f)
+          x = (best.stats.central_tendency.to_f / report.stats.central_tendency.to_f)
           $stdout.printf "%.2fx slower", x
         end
         

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -52,7 +52,7 @@ module Benchmark
         if overlaps
           $stdout.print "same-ish: difference falls within error"
         else
-          slowdown = report.stats.slowdown(best)
+          slowdown = report.stats.slowdown(best.stats)
           $stdout.printf "%.2fx slower", slowdown
         end
         

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module Benchmark
   # Functionality of performaing comparison between reports.
   #

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -52,8 +52,12 @@ module Benchmark
         if overlaps
           $stdout.print "same-ish: difference falls within error"
         else
-          slowdown = report.stats.slowdown(best.stats)
-          $stdout.printf "%.2fx slower", slowdown
+          slowdown, error = report.stats.slowdown(best.stats)
+          $stdout.printf "%.2fx ", slowdown
+          if error
+            $stdout.printf " (± %.2f)", error
+          end
+          $stdout.print " slower"
         end
         
         $stdout.puts

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -52,8 +52,8 @@ module Benchmark
         if overlaps
           $stdout.print "same-ish: difference falls within error"
         else
-          x = (best.stats.central_tendency.to_f / report.stats.central_tendency.to_f)
-          $stdout.printf "%.2fx slower", x
+          slowdown = report.stats.slowdown(best)
+          $stdout.printf "%.2fx slower", slowdown
         end
         
         $stdout.puts

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'benchmark/timing'
 require 'benchmark/compare'
+require 'benchmark/ips/stats/sd'
 require 'benchmark/ips/report'
 require 'benchmark/ips/job/entry'
 require 'benchmark/ips/job/stdout_report'

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -2,6 +2,7 @@
 require 'benchmark/timing'
 require 'benchmark/compare'
 require 'benchmark/ips/stats/sd'
+require 'benchmark/ips/stats/bootstrap'
 require 'benchmark/ips/report'
 require 'benchmark/ips/job/entry'
 require 'benchmark/ips/job/stdout_report'

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -225,7 +225,7 @@ module Benchmark
           if hold? && @held_results && @held_results.key?(item.label)
            result = @held_results[item.label]
             create_report(item.label, result['measured_us'], result['iter'],
-              result['avg_ips'], result['sd_ips'], result['cycles'])
+              result['samples'], result['cycles'])
             next
           end
           
@@ -261,14 +261,11 @@ module Benchmark
 
           measured_us = measurements_us.inject(0) { |a,i| a + i }
 
-          all_ips = measurements_us.map { |time_us|
+          samples = measurements_us.map { |time_us|
             iterations_per_sec cycles, time_us
           }
 
-          avg_ips = Timing.mean(all_ips)
-          sd_ips =  Timing.stddev(all_ips, avg_ips).round
-
-          rep = create_report(item.label, measured_us, iter, avg_ips, sd_ips, cycles)
+          rep = create_report(item.label, measured_us, iter, samples, cycles)
 
           if (final_time - target).abs >= (@time.to_f * MAX_TIME_SKEW)
             rep.show_total_time!
@@ -284,8 +281,7 @@ module Benchmark
                 :item => item.label,
                 :measured_us => measured_us,
                 :iter => iter,
-                :avg_ips => avg_ips,
-                :sd_ips => sd_ips,
+                :samples => samples,
                 :cycles => cycles
               })
               f.write "\n"
@@ -316,12 +312,11 @@ module Benchmark
       # @param label [String] Report item label.
       # @param measured_us [Integer] Measured time in microsecond.
       # @param iter [Integer] Iterations.
-      # @param avg_ips [Float] Average iterations per second.
-      # @param sd_ips [Float] Standard deviation iterations per second.
+      # @param samples [Array<Float>] Sampled iterations per second.
       # @param cycles [Integer] Number of Cycles.
       # @return [Report::Entry] Entry with data.
-      def create_report(label, measured_us, iter, avg_ips, sd_ips, cycles)
-        @full_report.add_entry label, measured_us, iter, avg_ips, sd_ips, cycles
+      def create_report(label, measured_us, iter, samples, cycles)
+        @full_report.add_entry label, measured_us, iter, samples, cycles
       end
     end
   end

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -193,6 +193,8 @@ module Benchmark
         @iterations.times do |n|
           held = run_benchmark
         end
+
+        @stdout.footer
         
         if held
           puts

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -194,7 +194,7 @@ module Benchmark
           held = run_benchmark
         end
 
-        @stdout.footer
+        @stdout.footer if @stdout
         
         if held
           puts

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -42,6 +42,14 @@ module Benchmark
       # @return [Integer]
       attr_accessor :iterations
 
+      # Statistics model.
+      # @return [Object]
+      attr_accessor :stats
+
+      # Confidence.
+      # @return [Integer]
+      attr_accessor :confidence
+
       # Instantiate the Benchmark::IPS::Job.
       # @option opts [Benchmark::Suite] (nil) :suite Specify Benchmark::Suite.
       # @option opts [Boolean] (false) :quiet Suppress the printing of information.
@@ -61,6 +69,10 @@ module Benchmark
         @warmup = 2
         @time = 5
         @iterations = 1
+
+        # Default statistical model
+        @stats = :sd
+        @confidence = 95
       end
 
       # Job configuration options, set +@warmup+ and +@time+.
@@ -72,6 +84,8 @@ module Benchmark
         @time = opts[:time] if opts[:time]
         @suite = opts[:suite] if opts[:suite]
         @iterations = opts[:iterations] if opts[:iterations]
+        @stats = opts[:stats] if opts[:stats]
+        @confidence = opts[:confidence] if opts[:confidence]
       end
 
       # Return true if job needs to be compared.
@@ -225,7 +239,7 @@ module Benchmark
           if hold? && @held_results && @held_results.key?(item.label)
            result = @held_results[item.label]
             create_report(item.label, result['measured_us'], result['iter'],
-              result['samples'], result['cycles'])
+                          create_stats(result['samples']), result['cycles'])
             next
           end
           
@@ -265,7 +279,7 @@ module Benchmark
             iterations_per_sec cycles, time_us
           }
 
-          rep = create_report(item.label, measured_us, iter, samples, cycles)
+          rep = create_report(item.label, measured_us, iter, create_stats(samples), cycles)
 
           if (final_time - target).abs >= (@time.to_f * MAX_TIME_SKEW)
             rep.show_total_time!
@@ -296,6 +310,17 @@ module Benchmark
         end
         
         false
+      end
+
+      def create_stats(samples)
+        case @stats
+          when :sd
+            Stats::SD.new(samples)
+          when :bootstrap
+            Stats::Bootstrap.new(samples, @confidence)
+          else
+            raise "unknown stats #{@stats}"
+        end
       end
 
       # Run comparison of entries in +@full_report+.

--- a/lib/benchmark/ips/job/stdout_report.rb
+++ b/lib/benchmark/ips/job/stdout_report.rb
@@ -27,6 +27,12 @@ module Benchmark
 
         def add_report(item, caller)
           $stdout.puts " #{item.body}"
+          @last_item = item
+        end
+
+        def footer
+          footer = @last_item.stats.footer
+          $stdout.puts footer.rjust(40) if footer
         end
 
         private

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -13,16 +13,15 @@ module Benchmark
         # @param [#to_s] label Label of entry.
         # @param [Integer] us Measured time in microsecond.
         # @param [Integer] iters Iterations.
-        # @param [Float] samples Sampled iterations per second.
+        # @param [Object] stats Statistics.
         # @param [Integer] cycles Number of Cycles.
-        def initialize(label, us, iters, samples, cycles)
+        def initialize(label, us, iters, stats, cycles)
           @label = label
           @microseconds = us
           @iterations = iters
-          @samples = samples
+          @stats = stats
           @measurement_cycle = cycles
           @show_total_time = false
-          @stats = Stats::SD.new(samples)
         end
 
         # Label of entry.
@@ -36,10 +35,6 @@ module Benchmark
         # Number of Iterations.
         # @return [Integer] number of iterations.
         attr_reader :iterations
-
-        # Sampled iterations per second.
-        # @return [Array<Float>] sampled iterations per second.
-        attr_reader :samples
 
         # Statistical summary of samples.
         # @return [Object] statisical summary.
@@ -130,11 +125,11 @@ module Benchmark
       # @param label [String] Entry label.
       # @param microseconds [Integer] Measured time in microsecond.
       # @param iters [Integer] Iterations.
-      # @param samples [Float<Float>] Sampled iterations per second.
+      # @param stats [Object] Statistical results.
       # @param measurement_cycle [Integer] Number of cycles.
       # @return [Report::Entry] Last added entry.
-      def add_entry label, microseconds, iters, samples, measurement_cycle
-        entry = Entry.new(label, microseconds, iters, samples, measurement_cycle)
+      def add_entry label, microseconds, iters, stats, measurement_cycle
+        entry = Entry.new(label, microseconds, iters, stats, measurement_cycle)
         @entries.delete_if { |e| e.label == label }
         @entries << entry
         entry
@@ -153,8 +148,8 @@ module Benchmark
         @data ||= @entries.collect do |entry|
           {
             :name => entry.label,
-            :ips =>  entry.ips,
-            :stddev => entry.ips_sd,
+            :ips =>  entry.stats.central_tendency,
+            :error => entry.stats.error,
             :microseconds => entry.microseconds,
             :iterations => entry.iterations,
             :cycles => entry.measurement_cycle,

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -148,8 +148,10 @@ module Benchmark
         @data ||= @entries.collect do |entry|
           {
             :name => entry.label,
-            :ips =>  entry.stats.central_tendency,
+            :central_tendency =>  entry.stats.central_tendency,
+            :ips =>  entry.stats.central_tendency, # for backwards compatibility
             :error => entry.stats.error,
+            :stddev => entry.stats.error, # for backwards compatibility
             :microseconds => entry.microseconds,
             :iterations => entry.iterations,
             :cycles => entry.measurement_cycle,

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -64,7 +64,7 @@ module Benchmark
 
         # Return entry's standard deviation of iteration per second in percentage.
         # @return [Float] +@ips_sd+ in percentage.
-        def stddev_percentage
+        def error_percentage
           100.0 * (@stats.error.to_f / @stats.central_tendency)
         end
 
@@ -77,7 +77,7 @@ module Benchmark
         def body
           case Benchmark::IPS.options[:format]
           when :human
-            left = "%s (±%4.1f%%) i/s" % [Helpers.scale(@stats.central_tendency), stddev_percentage]
+            left = "%s (±%4.1f%%) i/s" % [Helpers.scale(@stats.central_tendency), error_percentage]
             iters = Helpers.scale(@iterations)
 
             if @show_total_time
@@ -86,7 +86,7 @@ module Benchmark
               left.ljust(20) + (" - %s" % iters)
             end
           else
-            left = "%10.1f (±%.1f%%) i/s" % [@stats.central_tendency, stddev_percentage]
+            left = "%10.1f (±%.1f%%) i/s" % [@stats.central_tendency, error_percentage]
 
             if @show_total_time
               left.ljust(20) + (" - %10d in %10.6fs" % [@iterations, runtime])

--- a/lib/benchmark/ips/stats/bootstrap.rb
+++ b/lib/benchmark/ips/stats/bootstrap.rb
@@ -7,7 +7,7 @@ module Benchmark
         attr_reader :data
 
         def initialize(samples, confidence)
-          require 'kalibera'
+          dependencies
           @iterations = 10_000
           @confidence = (confidence / 100.0).to_s
           @data = Kalibera::Data.new({[0] => samples}, [1, samples.size])
@@ -28,6 +28,16 @@ module Benchmark
           low, slowdown, high = baseline.data.bootstrap_quotient(@data, @iterations, @confidence)
           error = Timing.mean([slowdown - low, high - slowdown])
           [slowdown, error]
+        end
+
+        def dependencies
+          require 'kaliberax'
+        rescue LoadError
+          puts
+          puts "Can't load the kalibera gem - this is required to use the :bootstrap stats options."
+          puts "It's optional, so we don't formally depend on it and it isn't installed along with benchmark-ips."
+          puts "You probably want to do something like 'gem install kalibera' to fix this."
+          abort
         end
 
       end

--- a/lib/benchmark/ips/stats/bootstrap.rb
+++ b/lib/benchmark/ips/stats/bootstrap.rb
@@ -30,6 +30,10 @@ module Benchmark
           [slowdown, error]
         end
 
+        def footer
+          "with #{(@confidence.to_f * 100).round(1)}% confidence"
+        end
+
         def dependencies
           require 'kalibera'
         rescue LoadError

--- a/lib/benchmark/ips/stats/bootstrap.rb
+++ b/lib/benchmark/ips/stats/bootstrap.rb
@@ -31,7 +31,7 @@ module Benchmark
         end
 
         def dependencies
-          require 'kaliberax'
+          require 'kalibera'
         rescue LoadError
           puts
           puts "Can't load the kalibera gem - this is required to use the :bootstrap stats options."

--- a/lib/benchmark/ips/stats/bootstrap.rb
+++ b/lib/benchmark/ips/stats/bootstrap.rb
@@ -1,0 +1,31 @@
+module Benchmark
+  module IPS
+    module Stats
+
+      class Bootstrap
+
+        def initialize(samples, confidence)
+          require 'kalibera'
+          data = Kalibera::Data.new({[0] => samples}, [1, samples.size])
+          interval = data.bootstrap_confidence_interval(10000, (confidence / 100.0).to_s)
+          @median = interval.median
+          @error = interval.error
+        end
+
+        def central_tendency
+          @median
+        end
+
+        def error
+          @error
+        end
+
+        def slowdown(baseline)
+          baseline.central_tendency.to_f / central_tendency
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/benchmark/ips/stats/sd.rb
+++ b/lib/benchmark/ips/stats/sd.rb
@@ -1,0 +1,24 @@
+module Benchmark
+  module IPS
+    module Stats
+      
+      class SD
+        
+        def initialize(samples)
+          @mean = Timing.mean(samples)
+          @error = Timing.stddev(samples, @mean).round
+        end
+        
+        def central_tendency
+          @mean
+        end
+        
+        def error
+          @error
+        end
+        
+      end
+    
+    end
+  end
+end

--- a/lib/benchmark/ips/stats/sd.rb
+++ b/lib/benchmark/ips/stats/sd.rb
@@ -18,7 +18,8 @@ module Benchmark
         end
 
         def slowdown(baseline)
-          baseline.central_tendency.to_f / central_tendency
+          slowdown = baseline.central_tendency.to_f / central_tendency
+          [slowdown, nil]
         end
         
       end

--- a/lib/benchmark/ips/stats/sd.rb
+++ b/lib/benchmark/ips/stats/sd.rb
@@ -16,6 +16,10 @@ module Benchmark
         def error
           @error
         end
+
+        def slowdown(baseline)
+          baseline.central_tendency.to_f / central_tendency
+        end
         
       end
     

--- a/lib/benchmark/ips/stats/sd.rb
+++ b/lib/benchmark/ips/stats/sd.rb
@@ -21,6 +21,10 @@ module Benchmark
           slowdown = baseline.central_tendency.to_f / central_tendency
           [slowdown, nil]
         end
+
+        def footer
+          nil
+        end
         
       end
     

--- a/lib/benchmark/timing.rb
+++ b/lib/benchmark/timing.rb
@@ -31,20 +31,6 @@ module Benchmark
       Math.sqrt variance(samples, m)
     end
 
-    # Resample mean of given samples.
-    # @param [Integer] resample_times Resample times, defaults to 100.
-    # @return [Array] Resampled samples.
-    def self.resample_mean(samples, resample_times=100)
-      resamples = []
-
-      resample_times.times do
-        resample = samples.map { samples[rand(samples.size)] }
-        resamples << Timing.mean(resample)
-      end
-
-      resamples
-    end
-
     # Recycle used objects by starting Garbage Collector.
     def self.clean_env
       # rbx

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -55,11 +55,11 @@ class TestBenchmarkIPS < Minitest::Test
 
     assert_equal "sleep 0.25", rep1.label
     assert_equal 4, rep1.iterations
-    assert_in_delta 4.0, rep1.ips, 0.2
+    assert_in_delta 4.0, rep1.stats.central_tendency, 0.2
 
     assert_equal "sleep 0.05", rep2.label
     assert_in_delta 20.0, rep2.iterations.to_f, 1.0
-    assert_in_delta 20.0, rep2.ips, 2.0
+    assert_in_delta 20.0, rep2.stats.central_tendency, 2.0
   end
 
   def test_ips_alternate_config
@@ -73,7 +73,7 @@ class TestBenchmarkIPS < Minitest::Test
 
     assert_equal "sleep 0.25", rep.label
     assert_equal 4, rep.iterations
-    assert_in_delta 4.0, rep.ips, 0.4
+    assert_in_delta 4.0, rep.stats.central_tendency, 0.4
   end
 
   def test_ips_old_config
@@ -85,7 +85,7 @@ class TestBenchmarkIPS < Minitest::Test
 
     assert_equal "sleep 0.25", rep.label
     assert_equal 4, rep.iterations
-    assert_in_delta 4.0, rep.ips, 0.2
+    assert_in_delta 4.0, rep.stats.central_tendency, 0.2
   end
 
   def test_ips_config_suite
@@ -112,7 +112,7 @@ class TestBenchmarkIPS < Minitest::Test
 
     assert_equal "sleep 0.25", rep.label
     assert_equal 4*5, rep.iterations
-    assert_in_delta 4.0, rep.ips, 0.2
+    assert_in_delta 4.0, rep.stats.central_tendency, 0.2
   end
 
   def test_ips_report_using_symbol
@@ -124,7 +124,7 @@ class TestBenchmarkIPS < Minitest::Test
 
     assert_equal :sleep_a_quarter_second, rep.label
     assert_equal 4*5, rep.iterations
-    assert_in_delta 4.0, rep.ips, 0.2
+    assert_in_delta 4.0, rep.stats.central_tendency, 0.2
   end
 
   def test_ips_default_data


### PR DESCRIPTION
Current output:

```
Warming up --------------------------------------
                 mul   243.455k i/100ms
                 pow   274.906k i/100ms
Calculating -------------------------------------
                 mul      5.635M (± 8.4%) i/s -     27.997M in   5.014078s
                 pow      7.674M (± 5.1%) i/s -     38.487M in   5.029545s

Comparison:
                 pow:  7674355.1 i/s
                 mul:  5635018.0 i/s - 1.36x  slower
```

With confidence intervals:

```
Warming up --------------------------------------
                 mul   244.458k i/100ms
                 pow   282.247k i/100ms
Calculating -------------------------------------
                 mul      5.996M (± 0.6%) i/s -     30.068M in   5.020666s
                 pow      8.035M (± 1.1%) i/s -     39.797M in   5.000516s
                   with 95.0% confidence

Comparison:
                 pow:  8034594.6 i/s
                 mul:  5996097.6 i/s - 1.34x  (± 0.02) slower
                   with 95.0% confidence
```

Why are confidence intervals good? The standard deviation isn't really actionable. If I tell you something is plus/mins X SD, what can you do with that? If I tell you something is plus/minus X and I'm 95% confident about that then you can theoretically use that in a quantitive assessment of the risk and cost of being wrong and use that to make a decision. It also isn't parametric - you can't make it smaller if you want more certainty, or larger if you are more relaxed.

Another big benefit is that we can show a confidence interval for the comparison as well! This isn't something that isn't possible at the moment.

Finally, I think the standard deviation is overly conservative, and confidence intervals are smaller in practice. From experience using `benchmark-ips`, the standard deviations we currently use are not useful because they're so large.

Adds an optional dependency on the `kalibera` gem.

@thedarkone what do you think?