### PR TITLE
Add missing files to Manifest

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -11,5 +11,7 @@ lib/benchmark/ips/job/entry.rb
 lib/benchmark/ips/job/stdout_report.rb
 lib/benchmark/ips/report.rb
 lib/benchmark/ips/share.rb
+lib/benchmark/ips/stats/bootstrap.rb
+lib/benchmark/ips/stats/sd.rb
 lib/benchmark/timing.rb
 test/test_benchmark_ips.rb


### PR DESCRIPTION
Stack trace:

    active_support/dependencies.rb:293:in `require': cannot load such file -- benchmark/ips/stats/sd (LoadError)

    gems/ruby-2.3.1/gems/benchmark-ips-2.7.0/lib/benchmark/ips.rb:4:in `<top (required)>'
