### PR TITLE
Fix files missing from gemspec

### DIFF
--- a/benchmark-ips.gemspec
+++ b/benchmark-ips.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.description = "A iterations per second enhancement to Benchmark."
   s.email = ["evan@phx.io"]
   s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.md"]
-  s.files = [".autotest", ".gemtest", "History.txt", "Manifest.txt", "README.md", "Rakefile", "lib/benchmark/compare.rb", "lib/benchmark/ips.rb", "lib/benchmark/ips/job.rb", "lib/benchmark/ips/report.rb", "lib/benchmark/timing.rb", "test/test_benchmark_ips.rb"]
+  s.files = Dir[".autotest", ".gemtest", "History.txt", "Manifest.txt", "README.md", "Rakefile", "lib/**/*.rb"]
   s.homepage = "https://github.com/evanphx/benchmark-ips"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.md"]


### PR DESCRIPTION
Looks like this has happened before #59 and this should prevent it from
happeing again by including all files lib.

Fixes #74