### PR TITLE
[WIP] Extensible jobs

### DIFF
--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -26,12 +26,17 @@ module Benchmark
   #   Reduce using to_proc:   247295.4 i/s - 1.13x slower
   #
   # Besides regular Calculating report, this will also indicates which one is slower.
-  module Compare
+  class Compare
+
+    # currently the core of the run is part of job#run and job#run_benchmark
+    def run(job)
+    end
 
     # Compare between reports, prints out facts of each report:
     # runtime, comparative speed difference.
-    # @param entries [Array<Report::Entry>] Reports to compare.
-    def compare(*entries)
+    # @param entries [Benchmark::IPS::Report] Report to compare.
+    def post_run(full_report)
+      entries = full_report.entries
       return if entries.size < 2
 
       sorted = entries.sort_by{ |e| e.stats.central_tendency }.reverse
@@ -67,6 +72,4 @@ module Benchmark
       $stdout.puts
     end
   end
-
-  extend Benchmark::Compare
 end

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require 'benchmark/timing'
-require 'benchmark/compare'
 require 'benchmark/ips/stats/stats_metric'
 require 'benchmark/ips/stats/sd'
 require 'benchmark/ips/stats/bootstrap'

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -55,7 +55,7 @@ module Benchmark
 
       yield job
 
-      job.load_held_results
+      job.pre_run
 
       job.run
 
@@ -67,18 +67,9 @@ module Benchmark
       end
 
       $stdout.sync = sync
-      job.run_comparison
-      job.generate_json
+      job.post_run
 
-      report = job.full_report
-
-      if ENV['SHARE'] || ENV['SHARE_URL']
-        require 'benchmark/ips/share'
-        share = Share.new report, job
-        share.share
-      end
-
-      report
+      job.full_report
     end
 
     # Set options for running the benchmarks.

--- a/lib/benchmark/ips/json_report.rb
+++ b/lib/benchmark/ips/json_report.rb
@@ -1,0 +1,19 @@
+module Benchmark
+  module IPS
+    class JsonReport
+      def initialize(json_path)
+        @json_path = json_path
+      end
+
+      def run(job)
+      end
+
+      def post_run(report)
+        File.open @json_path , "w" do |f|
+          require "json"
+          f.write JSON.pretty_generate(report.data)
+        end
+      end
+    end
+  end
+end

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -174,20 +174,6 @@ module Benchmark
           }
         end
       end
-
-      # Run comparison of entries.
-      def run_comparison
-        Benchmark.compare(*@entries)
-      end
-
-      # Generate json from Report#data to given path.
-      # @param path [String] path to generate json.
-      def generate_json(path)
-        File.open path, "w" do |f|
-          require "json"
-          f.write JSON.pretty_generate(data)
-        end
-      end
     end
   end
 end

--- a/lib/benchmark/ips/share.rb
+++ b/lib/benchmark/ips/share.rb
@@ -6,21 +6,23 @@ module Benchmark
   module IPS
     class Share
       DEFAULT_URL = "https://benchmark.fyi"
-      def initialize(report, job)
-        @report = report
-        @job = job
+      def initialize(job_compare)
+        @job_compare = job_compare
       end
 
-      def share
+      def run(job)
+      end
+
+      def post_run(report)
         base = (ENV['SHARE_URL'] || DEFAULT_URL)
         url = URI(File.join(base, "reports"))
 
         req = Net::HTTP::Post.new(url)
 
         data = {
-          "entries" => @report.data,
+          "entries" => report.data,
           "options" => {
-            "compare" => @job.compare?
+            "compare" => @job_compare
           }
         }
 


### PR DESCRIPTION
Hi @evanphx 

I find I often want to extend `benchmark-ips` to add number of objects allocated or number of queries performed and others.

There are a few memory alternatives like https://github.com/michaelherold/benchmark-memory (there was another, can't find it), but to be honest, it would be nice if there were just one base for this mostly common code. I was hoping to keep `benchmark-ips` as the base glue that would be able to run multiple types of benchmarks. (probably not your main goal)

I think the first 2 commits are no-brainers.
Possibly the 3rd is as well.
If you prefer, I can pull some of those out into a separate PR and go from there.