### PR TITLE
Report to stream and iron out compare abstraction

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -7,6 +7,7 @@ require 'benchmark/ips/stats/bootstrap'
 require 'benchmark/ips/report'
 require 'benchmark/ips/job/entry'
 require 'benchmark/ips/job/stdout_report'
+require 'benchmark/ips/job/multi_report'
 require 'benchmark/ips/job'
 
 # Performance benchmarking library

--- a/lib/benchmark/ips/job/multi_report.rb
+++ b/lib/benchmark/ips/job/multi_report.rb
@@ -1,0 +1,52 @@
+module Benchmark
+  module IPS
+    class Job
+      class MultiReport
+        # @returns out [Array<StdoutReport>] list of reports to send output
+        attr_accessor :out
+
+        def empty?
+          @out.empty?
+        end
+
+        # @param report [StdoutReport] report to accept input?
+        def <<(report)
+          @out << report
+        end
+
+        # @param out [Array<StdoutReport>] list of reports to send output
+        def initialize(out = [])
+          @out = out
+        end
+
+        def start_warming
+          @out.each { |o| o.start_warming }
+        end
+
+        def start_running
+          @out.each { |o| o.start_running }
+        end
+
+        def warming(label, _warmup)
+          @out.each { |o| o.warming(label, _warmup) }
+        end
+
+        def running(label, _warmup)
+          @out.each { |o| o.running(label, _warmup) }
+        end
+
+        def warmup_stats(_warmup_time_us, timing)
+          @out.each { |o| o.warmup_stats(_warmup_time_us, timing) }
+        end
+
+        def add_report(item, caller)
+          @out.each { |o| o.add_report(item, caller) }
+        end
+
+        def footer
+          @out.each { |o| o.footer }
+        end
+      end
+    end
+  end
+end

--- a/lib/benchmark/ips/job/stdout_report.rb
+++ b/lib/benchmark/ips/job/stdout_report.rb
@@ -2,42 +2,43 @@ module Benchmark
   module IPS
     class Job
       class StdoutReport
-        def initialize
+        def initialize(stream = $stdout)
           @last_item = nil
+          @out = stream
         end
 
         def start_warming
-          $stdout.puts "Warming up --------------------------------------"
+          @out.puts "Warming up --------------------------------------"
         end
 
         def start_running
-          $stdout.puts "Calculating -------------------------------------"
+          @out.puts "Calculating -------------------------------------"
         end
 
         def warming(label, _warmup)
-          $stdout.print rjust(label)
+          @out.print rjust(label)
         end
 
         def warmup_stats(_warmup_time_us, timing)
           case format
           when :human
-            $stdout.printf "%s i/100ms\n", Helpers.scale(timing)
+            @out.printf "%s i/100ms\n", Helpers.scale(timing)
           else
-            $stdout.printf "%10d i/100ms\n", timing
+            @out.printf "%10d i/100ms\n", timing
           end
         end
 
         alias_method :running, :warming
 
         def add_report(item, caller)
-          $stdout.puts " #{item.body}"
+          @out.puts " #{item.body}"
           @last_item = item
         end
 
         def footer
           return unless @last_item
           footer = @last_item.stats.footer
-          $stdout.puts footer.rjust(40) if footer
+          @out.puts footer.rjust(40) if footer
         end
 
         private

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -113,7 +113,7 @@ class TestBenchmarkIPS < Minitest::Test
       x.report("job") {}
     end
 
-    assert_equal [:warming, :warmup_stats, :running, :add_report], suite.calls
+    assert_equal [:start_warming, :warming, :warmup_stats, :start_running, :running, :add_report, :footer], suite.calls
   end
 
   def test_ips_defaults


### PR DESCRIPTION
This unifies the double `@stdout` and `@suite` calls. It also allows a user to choose a different output.

Addresses #81 for `warmup` and `benchmark` but not `compare!`

Outstanding:

Changing `compare` is not as easy, the output needs to be passed in:
1. Pass in the stream from one of the `@outs`
2. Pass in a stream to `config` and use that throughout
3. Enhance `StdoutReport` and change `compare` to use the `@outs`.

Let me know which you approach you prefer. I can fixup this PR or just make another.

### Sample Code

```ruby
require "benchmark/ips"

my_stream = StringIO.new
Benchmark.ips do |x|
  x.config(:quiet => true, :suite => ::Benchmark::IPS::Job::StdoutReport.new(my_stream))

  x.report("mul") { 2 * 2 * 2 * 2 * 2 * 2 * 2 * 2 }
  x.report("pow") { 2 ** 8 }

  # x.compare!
end

puts "results: #{my_stream.string}"
```
