### PR TITLE
Run more than just 1 cycle during warmup to reduce overhead

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -247,21 +247,33 @@ module Benchmark
 
           Timing.clean_env
 
+          # Run for up to half of the configured warmup time with an increasing
+          # number of cycles to reduce overhead and improve accuracy.
+          # This also avoids running with a constant number of cycles, which a
+          # JIT might speculate on and then have to recompile in #run_benchmark.
           before = Timing.now
-          target = Timing.add_second before, @warmup
+          target = Timing.add_second before, @warmup / 2.0
 
-          warmup_iter = 0
-
-          while Timing.now < target
-            item.call_times(1)
-            warmup_iter += 1
+          cycles = 1
+          warmup_iter = 1
+          warmup_time_us = 0.0
+          while Timing.now + warmup_time_us * 2 < target
+            t0 = Timing.now
+            item.call_times cycles
+            t1 = Timing.now
+            warmup_iter = cycles
+            warmup_time_us = Timing.time_us(t0, t1)
+            cycles *= 2
           end
 
-          after = Timing.now
+          cycles = cycles_per_100ms warmup_time_us, warmup_iter
+          @timing[item] = cycles
 
-          warmup_time_us = Timing.time_us(before, after)
-
-          @timing[item] = cycles_per_100ms warmup_time_us, warmup_iter
+          # Run for the remaining of warmup in a similar way as #run_benchmark.
+          target = Timing.add_second before, @warmup
+          while Timing.now + MICROSECONDS_PER_100MS < target
+            item.call_times cycles
+          end
 
           @stdout.warmup_stats warmup_time_us, @timing[item] if @stdout
           @suite.warmup_stats warmup_time_us, @timing[item] if @suite


### PR DESCRIPTION
* That way, warmup is more similar to actual measurements and not wildly
  different due to the overhead of going through #call_times in and out
  on every cycle.
* This also communicates to the JIT that cycles is not always 1, which
  means the method compiled during warmup is more likely to be re-used.
  Before, the compiled method could deoptimize because `run_warmup` always
  calls `call_times` with cycles=1 and the JIT might speculate on that
  to remove the loop, but then `run_benchmark` suddenly calls `call_times`
  with cycles > 1, which needs the loop and therefore causes deoptimization
  and later recompilation, during the actual measurements.

This PR addresses the second issue of the benchmark shown in #95.
I believe it also addresses #94, cc @ioquatix
```ruby
# frozen_string_literal: true
require 'benchmark/ips'

module ActiveSupport
  class StringInquirer < String
    def method_missing(method_name, *arguments)
      if method_name[-1] == "?"
        self == method_name[0..-2]
      else
        super
      end
    end
  end
end

def env
  @_env ||= ActiveSupport::StringInquirer.new("development")
end

Benchmark.ips do |x|
  x.iterations = 2

  x.report("env.development?") do
    env.development?
  end

  x.report("env == 'development'") do
    env == 'development'
  end
end
```
When running this benchmark on MRI with current master, I see:
```
$ ruby -I/home/eregon/code/benchmark-ips/lib bench_dev.rb
Warming up --------------------------------------
    env.development?   200.814k i/100ms
env == 'development'   423.283k i/100ms
    env.development?   201.198k i/100ms
env == 'development'   426.050k i/100ms
Calculating -------------------------------------
    env.development?      2.783M (± 1.9%) i/s -     14.084M in   5.062861s
env == 'development'     10.756M (± 1.3%) i/s -     54.108M in   5.031362s
    env.development?      2.782M (± 1.2%) i/s -     14.084M in   5.062568s
env == 'development'     10.818M (± 1.0%) i/s -     54.108M in   5.002086s
```

I noticed the warming times, which are per 100ms are not really close to a 10th of the measurement times, which are in 1000ms (1 second). This sounds surprising, as on MRI for this benchmark I would expect no difference between warmup and actual measurement.
Yet, we see `env == 'development'` is 426k i/100ms (= 4.26M i/s) during warmup and then it's 10.818M i/s during measurements. Did MRI get magically more than twice faster when it realized we are actually benchmarking and not just warming up? I would not think so.

The reason is the warmup phase uses `call_times(cycles=1)` while the measurement phase uses `call_times(cycles)` with `cycles` typically far great than 1 (in this case, around 200 000).
Using `call_times(1)` has a significant overhead as shown here, because every time we need to go in call_times:
https://github.com/evanphx/benchmark-ips/blob/0bb23ea1f5d8f65416629505889f6dfc550fa4a6/lib/benchmark/ips/job/entry.rb#L46-L56
Read a few instance variables, go in the loop for just one call, exit the loop and return from `call_times`.

So instead, if we adapt the warmup to call `call_times` with enough cycles to take at least 1ms, we will reduce the overhead significantly, as this PR does:
```
$ ruby -I/home/eregon/code/benchmark-ips/lib bench_dev.rb
Warming up --------------------------------------
    env.development?   274.007k i/100ms
env == 'development'     1.049M i/100ms
    env.development?   274.043k i/100ms
env == 'development'     1.035M i/100ms
Calculating -------------------------------------
    env.development?      2.787M (± 6.0%) i/s -     13.976M in   5.041526s
env == 'development'     10.717M (± 0.8%) i/s -     53.813M in   5.021777s
    env.development?      2.820M (± 0.8%) i/s -     14.250M in   5.053428s
env == 'development'     10.621M (± 0.6%) i/s -     53.813M in   5.067114s
```
Now warmup and measurement timings are consistent and make sense.

Of course, nobody should use only warmup times for interpreting results, but nevertheless I believe it's good for warmup and measurements times to match, as it can be an indication of whether enough warmup happened and how stable is the code being benchmarked.

The same issue also happens on TruffleRuby (because the warmup loop cannot be compiled efficiently with the previous code, only with OSR after many many iterations). Without this PR:
```
Warming up --------------------------------------
    env.development?   737.218k i/100ms
env == 'development'     1.900M i/100ms
    env.development?   945.329k i/100ms
env == 'development'     2.203M i/100ms
Calculating -------------------------------------
    env.development?     14.695M (±23.7%) i/s -     68.064M in   5.049277s
env == 'development'      1.219B (± 5.9%) i/s -      6.007B in   4.995364s
    env.development?     14.532M (±25.5%) i/s -     66.173M in   5.010910s
env == 'development'      1.243B (± 2.9%) i/s -      6.206B in   4.997811s
```
With this PR:
```
Warming up --------------------------------------
    env.development?     1.218M i/100ms
env == 'development'   107.143M i/100ms
    env.development?     1.518M i/100ms
env == 'development'   121.856M i/100ms
Calculating -------------------------------------
    env.development?     14.787M (±16.5%) i/s -     72.850M in   5.070296s
env == 'development'      1.244B (± 0.8%) i/s -      6.336B in   5.092835s
    env.development?     14.425M (±17.4%) i/s -     69.814M in   5.000543s
env == 'development'      1.233B (± 2.2%) i/s -      6.215B in   5.044568s
```
And warmup is then consistent with measurements (instead of being apparently much slower).

cc @chrisseaton 