### PR TITLE
Add missing stats_metric.rb to Manifest.txt

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -12,5 +12,6 @@ lib/benchmark/ips/report.rb
 lib/benchmark/ips/share.rb
 lib/benchmark/ips/stats/bootstrap.rb
 lib/benchmark/ips/stats/sd.rb
+lib/benchmark/ips/stats/stats_metric.rb
 lib/benchmark/timing.rb
 test/test_benchmark_ips.rb


### PR DESCRIPTION
Without this file gem version 2.8.0 (3dba7be) will throw a `LoadError` when you attempt to `require 'benchmark/ips'`:

`LoadError (cannot load such file -- benchmark/ips/stats/stats_metric)`