### PR TITLE
Avoid overflow during warmup when the cycles would become >= 2**31

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -9,6 +9,7 @@ module Benchmark
       # The percentage of the expected runtime to allow
       # before reporting a weird runtime
       MAX_TIME_SKEW = 0.05
+      POW_2_30 = 1 << 30
 
       # Two-element arrays, consisting of label and block pairs.
       # @return [Array<Entry>] list of entries
@@ -263,6 +264,10 @@ module Benchmark
             t1 = Timing.now
             warmup_iter = cycles
             warmup_time_us = Timing.time_us(t0, t1)
+
+            # If the number of cycles would go outside the 32-bit signed integers range
+            # then exit the loop to avoid overflows and start the 100ms warmup runs
+            break if cycles >= POW_2_30
             cycles *= 2
           end
 


### PR DESCRIPTION
* See https://github.com/oracle/truffleruby/issues/2080
* The first job would be advantaged (for instance on TruffleRuby) because
  the first job would only call #call_times with `int` cycles,
  but for the next jobs `cycles` would be promoted to a `long` due to
  the last `cycles *= 2` at the end of the first job warmup, making the
  compiled code less efficient for the following jobs.
* Before:
```
Warming up --------------------------------------
                call   431.548M i/100ms
                send   209.063M i/100ms
      method_missing   211.518M i/100ms
Calculating -------------------------------------
                call      4.257B (± 2.5%) i/s -     21.577B in   5.071540s
                send      2.128B (± 0.6%) i/s -     10.662B in   5.009983s
      method_missing      2.105B (± 0.9%) i/s -     10.576B in   5.023898s

Comparison:
                call: 4257382144.9 i/s
                send: 2128282445.4 i/s - 2.00x  (± 0.00) slower
      method_missing: 2105291438.1 i/s - 2.02x  (± 0.00) slower
```
* After:
```
Warming up --------------------------------------
                call   428.105M i/100ms
                send   428.196M i/100ms
      method_missing   428.042M i/100ms
Calculating -------------------------------------
                call      4.298B (± 0.2%) i/s -     21.833B in   5.080217s
                send      4.295B (± 0.3%) i/s -     21.838B in   5.085086s
      method_missing      4.299B (± 0.2%) i/s -     21.830B in   5.078548s

Comparison:
      method_missing: 4298509323.4 i/s
                call: 4297742474.3 i/s - same-ish: difference falls within error
                send: 4294549352.9 i/s - same-ish: difference falls within error
```

@nateberkopec Could you review? :smiley: 