### PR TITLE
Fix broken hold! when results file didn't exist

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -188,7 +188,7 @@ module Benchmark
       end
 
       def load_held_results
-        return unless @held_path && !File.zero?(@held_path)
+        return unless @held_path && File.exist?(@held_path) && !File.zero?(@held_path)
         require "json"
         @held_results = {}
         JSON.load(IO.read(@held_path)).each do |result|

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -1,6 +1,7 @@
 require "minitest/autorun"
 require "benchmark/ips"
 require "stringio"
+require "tmpdir"
 
 class TestBenchmarkIPS < Minitest::Test
   def setup
@@ -181,5 +182,18 @@ class TestBenchmarkIPS < Minitest::Test
     assert_equal "sleep 0.25", data[0]["name"]
     assert data[0]["ips"]
     assert data[0]["stddev"]
+  end
+
+  def test_hold!
+    temp_file_name = Dir::Tmpname.create(["benchmark-ips", ".tmp"]) { }
+
+    Benchmark.ips(:time => 0.001, :warmup => 0.001) do |x|
+      x.report("operation") { 100 * 100 }
+      x.report("operation2") { 100 * 100 }
+      x.hold! temp_file_name
+    end
+
+    assert File.exist?(temp_file_name)
+    File.unlink(temp_file_name)
   end
 end


### PR DESCRIPTION
In ed5c005071, the fix to allow the held results to be empty broke use
of `hold!` when no pre-existing file existed.

This is because `File.zero?` of a non-existing file returns `false`,
and thus in `load_held_results` the early `return` would not happen,
resulting in a failed attempt to parse the non-existing file:

```
$ ruby examples/hold.rb
Traceback (most recent call last):
	3: from examples/hold.rb:22:in `<main>'
	2: from ~/ruby/benchmark-ips/lib/benchmark/ips.rb:58:in `ips'
	1: from ~/ruby/benchmark-ips/lib/benchmark/ips/job.rb:193:in `load_held_results'
~/ruby/benchmark-ips/lib/benchmark/ips/job.rb:193:in `read': No such file or directory @ rb_sysopen - temp_results (Errno::ENOENT)
```

the full fix here is to check that both:

* there is a file
* and it is not empty