### PR TITLE
Allow Suite To be Set via Accessor

### DIFF
--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -5,8 +5,10 @@ require 'benchmark/ips/stats/stats_metric'
 require 'benchmark/ips/stats/sd'
 require 'benchmark/ips/stats/bootstrap'
 require 'benchmark/ips/report'
+require 'benchmark/ips/noop_suite'
 require 'benchmark/ips/job/entry'
 require 'benchmark/ips/job/stdout_report'
+require 'benchmark/ips/job/noop_report'
 require 'benchmark/ips/job'
 
 # Performance benchmarking library
@@ -33,23 +35,14 @@ module Benchmark
         time, warmup, quiet = args
       end
 
-      suite = nil
-
       sync, $stdout.sync = $stdout.sync, true
 
-      if defined? Benchmark::Suite and Suite.current
-        suite = Benchmark::Suite.current
-      end
-
-      quiet ||= (suite && suite.quiet?)
-
-      job = Job.new({:suite => suite,
-                     :quiet => quiet
-      })
+      job = Job.new
 
       job_opts = {}
       job_opts[:time] = time unless time.nil?
       job_opts[:warmup] = warmup unless warmup.nil?
+      job_opts[:quiet] = quiet unless quiet.nil?
 
       job.config job_opts
 

--- a/lib/benchmark/ips/job/noop_report.rb
+++ b/lib/benchmark/ips/job/noop_report.rb
@@ -1,0 +1,27 @@
+module Benchmark
+  module IPS
+    class Job
+      class NoopReport
+        def start_warming
+        end
+
+        def start_running
+        end
+
+        def footer
+        end
+
+        def warming(a, b)
+        end
+
+        def warmup_stats(a, b)
+        end
+
+        def add_report(a, b)
+        end
+
+        alias_method :running, :warming
+      end
+    end
+  end
+end

--- a/lib/benchmark/ips/noop_suite.rb
+++ b/lib/benchmark/ips/noop_suite.rb
@@ -1,0 +1,25 @@
+module Benchmark
+  module IPS
+    class NoopSuite
+      def start_warming
+      end
+
+      def start_running
+      end
+
+      def footer
+      end
+
+      def warming(a, b)
+      end
+
+      def warmup_stats(a, b)
+      end
+
+      def add_report(a, b)
+      end
+
+      alias_method :running, :warming
+    end
+  end
+end

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -54,6 +54,13 @@ class TestBenchmarkIPS < Minitest::Test
     end
 
     assert $stdout.string.size.zero?
+
+    Benchmark.ips do |x|
+      x.quiet = true
+      x.report("operation") { 100 * 100 }
+    end
+
+    assert $stdout.string.size.zero?
   end
 
   def test_ips
@@ -111,6 +118,21 @@ class TestBenchmarkIPS < Minitest::Test
 
     Benchmark.ips(0.1, 0.1) do |x|
       x.config(:suite => suite)
+      x.report("job") {}
+    end
+
+    assert_equal [:warming, :warmup_stats, :running, :add_report], suite.calls
+  end
+
+  def test_ips_config_suite_by_accsr
+    suite = Struct.new(:calls) do
+      def method_missing(method, *args)
+        calls << method
+      end
+    end.new([])
+
+    Benchmark.ips(0.1, 0.1) do |x|
+      x.suite = suite
       x.report("job") {}
     end
 


### PR DESCRIPTION
This aims to close #112.

I removed references to `Benchmark::Suite` - I couldn't find anywhere
this was used and the original commit goes back a long ways.  This looks
like a relic to a class or module that I'm not able to find in git
history via

```
git grep 'Suite' $(git rev-list --all)
```

All config gets passed into `job.config job_opts` and now the block is
evaluated last allowing overrides.