### PR TITLE
Fix missing `noop_suite` and `job/noop_report` files in v2.9.0 Manifest

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -7,7 +7,9 @@ lib/benchmark/compare.rb
 lib/benchmark/ips.rb
 lib/benchmark/ips/job.rb
 lib/benchmark/ips/job/entry.rb
+lib/benchmark/ips/job/noop_report.rb
 lib/benchmark/ips/job/stdout_report.rb
+lib/benchmark/ips/noop_suite.rb
 lib/benchmark/ips/report.rb
 lib/benchmark/ips/share.rb
 lib/benchmark/ips/stats/bootstrap.rb


### PR DESCRIPTION
Previously: https://github.com/evanphx/benchmark-ips/issues/103
Previously previously: https://github.com/evanphx/benchmark-ips/issues/74
Previously previously previously: https://github.com/evanphx/benchmark-ips/issues/59

Before:

```[gst-master] [okeeblow@emi#CHECKING-YOU-OUT] ./bin/benchmark
Traceback (most recent call last):
        2: from ./bin/benchmark:7:in `<main>'
        1: from /usr/local/lib/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/usr/local/lib/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- benchmark/ips (LoadError)
        6: from ./bin/benchmark:7:in `<main>'
        5: from /usr/local/lib/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:156:in `require'
        4: from /usr/local/lib/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `rescue in require'
        3: from /usr/local/lib/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `require'
        2: from /home/okeeblow/.gems/gems/benchmark-ips-2.9.0/lib/benchmark/ips.rb:8:in `<top (required)>'
        1: from /usr/local/lib/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/usr/local/lib/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- benchmark/ips/noop_suite (LoadError)
```


Fix:

```[gst-master] [okeeblow@emi#CHECKING-YOU-OUT] curl -o /home/okeeblow/.gems/gems/benchmark-ips-2.9.0/lib/benchmark/ips/noop_suite.rb https://raw.githubusercontent.com/evanphx/benchmark-ips/master/lib/benchmark/ips/noop_suite.rb
[gst-master] [okeeblow@emi#CHECKING-YOU-OUT] curl -o /home/okeeblow/.gems/gems/benchmark-ips-2.9.0/lib/benchmark/ips/job/noop_report.rb https://raw.githubusercontent.com/evanphx/benchmark-ips/master/lib/benchmark/ips/job/noop_report.rb
```


After:

```[gst-master] [okeeblow@emi#CHECKING-YOU-OUT] bundle exec ./bin/benchmark

Memory stats for requiring mime/types/columnar
Total usable MIME::Types: 2315
Total allocated: 7050872 bytes (103543 objects)
Total retained:  2006910 bytes (22929 objects)

Memory stats for requiring mini_mime
Total allocated: 39004 bytes (324 objects)
Total retained:  8728 bytes (65 objects)

Memory stats for requiring CHECKING-YOU-OUT
Total usable CYO Types: 1467
Total allocated: 18256663 bytes (298015 objects)
Total retained:  484343 bytes (7684 objects)
```