### PR TITLE
! Fix quiet mode broken when config called without key `quiet`

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -79,6 +79,8 @@ module Benchmark
         # Default statistical model
         @stats = :sd
         @confidence = 95
+
+        self.quiet = false
       end
 
       # Job configuration options, set +@warmup+ and +@time+.
@@ -92,7 +94,7 @@ module Benchmark
         @iterations = opts[:iterations] if opts[:iterations]
         @stats = opts[:stats] if opts[:stats]
         @confidence = opts[:confidence] if opts[:confidence]
-        self.quiet = opts[:quiet]
+        self.quiet = opts[:quiet] if opts.key?(:quiet)
         self.suite = opts[:suite]
       end
 

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -70,6 +70,32 @@ class TestBenchmarkIPS < Minitest::Test
     assert $stdout.string.size.zero?
   end
 
+  def test_quiet_option_override
+    Benchmark.ips(quiet: true) do |x|
+      x.quiet = false
+      x.report("operation") { 100 * 100 }
+    end
+
+    assert $stdout.string.size > 0
+    $stdout.truncate(0)
+
+    Benchmark.ips(quiet: true) do |x|
+      x.config(quiet: false)
+      x.report("operation") { 100 * 100 }
+    end
+
+    assert $stdout.string.size > 0
+    $stdout.truncate(0)
+
+    Benchmark.ips(quiet: true) do |x|
+      # Calling config should not make quiet option overridden when no specified
+      x.config({})
+      x.report("operation") { 100 * 100 }
+    end
+
+    assert $stdout.string.size.zero?
+  end
+
   def test_ips
     report = Benchmark.ips do |x|
       x.config(:time => 1, :warmup => 1)


### PR DESCRIPTION
I have built some stuff relying on quiet mode several year ago
I recently try to run it again and found that it's broken due to this gem outputting results to stdout unexpectedly

Thus I found out about this bug