### PR TITLE
Return nil instead of 0 for relative error in SD

### DIFF
--- a/lib/benchmark/ips/stats/sd.rb
+++ b/lib/benchmark/ips/stats/sd.rb
@@ -24,9 +24,9 @@ module Benchmark
         # @returns [Array<Float, nil>] the slowdown and the error (not calculated for standard deviation)
         def slowdown(baseline)
           if baseline.central_tendency > central_tendency
-            [baseline.central_tendency.to_f / central_tendency, 0]
+            [baseline.central_tendency.to_f / central_tendency, nil]
           else
-            [central_tendency.to_f / baseline.central_tendency, 0]
+            [central_tendency.to_f / baseline.central_tendency, nil]
           end
         end
 


### PR DESCRIPTION
- When running in standard deviation mode, the error is hardcoded to return as zero. 
- Because the error is not actually calculated, it should be returned as `nil` instead.
- The [compare module is set up to handle the nil values](https://github.com/evanphx/benchmark-ips/blob/c8985572b7218bc074abf0b4af1a2b913eb5f094/lib/benchmark/compare.rb#L84) already and skip the output