### PR TITLE
Feat: Support JSON output to STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,29 @@ Benchmark.ips do |x|
 end
 ```
 
+### Output as JSON
+
+You can generate output in JSON. If you want to write JSON to a file, pass filename to `json!` method:
+
+```ruby
+Benchmark.ips do |x|
+  x.report("some report") {  }
+  x.json! 'filename.json'
+end
+```
+
+If you want to write JSON to STDOUT, pass `STDOUT` to `json!` method and set `quiet = true` before `json!`:
+
+```ruby
+Benchmark.ips do |x|
+  x.report("some report") {  }
+  x.quiet = true
+  x.json! STDOUT
+end
+```
+
+This is useful when the output from `benchmark-ips` becomes an input of other tools via stdin.
+
 ## REQUIREMENTS:
 
 * None!

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -183,9 +183,13 @@ module Benchmark
       # Generate json from Report#data to given path.
       # @param path [String] path to generate json.
       def generate_json(path)
-        File.open path, "w" do |f|
-          require "json"
-          f.write JSON.pretty_generate(data)
+        require "json"
+        if path.respond_to?(:write) # STDOUT
+          path.write JSON.pretty_generate(data)
+        else
+          File.open path, "w" do |f|
+            f.write JSON.pretty_generate(data)
+          end
         end
       end
     end

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -237,6 +237,23 @@ class TestBenchmarkIPS < Minitest::Test
     assert data[0]["stddev"]
   end
 
+  def test_json_output_to_stdout
+    Benchmark.ips do |x|
+      x.report("sleep 0.25") { sleep(0.25) }
+      x.quiet = true
+      x.json! $stdout
+    end
+
+    assert $stdout.string.size > 0
+
+    data = JSON.parse $stdout.string
+    assert data
+    assert_equal 1, data.size
+    assert_equal "sleep 0.25", data[0]["name"]
+    assert data[0]["ips"]
+    assert data[0]["stddev"]
+  end
+
   def test_hold!
     temp_file_name = Dir::Tmpname.create(["benchmark-ips", ".tmp"]) { }
 


### PR DESCRIPTION
I want to support `benchmark-ips` in github-action-benchmark.
https://github.com/benchmark-action/github-action-benchmark

When it can write the result to STDOUT in JSON format, it would be easy to support it.
This commits changes JSON output so that it can directly write to a given argument if it responds to `write`.
It also adds tests and a section about JSON in README.