### PR TITLE
Automatically print the Ruby description at the top of the report

### DIFF
--- a/lib/benchmark/ips/job/stream_report.rb
+++ b/lib/benchmark/ips/job/stream_report.rb
@@ -8,6 +8,7 @@ module Benchmark
         end
 
         def start_warming
+          @out.puts RUBY_DESCRIPTION
           @out.puts "Warming up --------------------------------------"
         end
 


### PR DESCRIPTION
It's something I usually manually do when sharing benchmark, but I generally don't see it in most of the benchmark results being shared out there, sometimes making it harder to reproduce the results.

I think it would be nice if benchmark-ips just always printed it.