### PR TITLE
Improve report to show duration/i (e.g: `12.34 ns/i`).

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,24 @@ end
 This will generate the following report:
 
 ```
+Warming up --------------------------------------
+            addition     3.572M i/100ms
+           addition2     3.672M i/100ms
+           addition3     3.677M i/100ms
+addition-test-long-label
+                         3.511M i/100ms
 Calculating -------------------------------------
-            addition    71.254k i/100ms
-           addition2    68.658k i/100ms
-           addition3    83.079k i/100ms
+            addition     36.209M (± 2.8%) i/s   (27.62 ns/i) -    182.253M in   5.037433s
+           addition2     36.552M (± 7.8%) i/s   (27.36 ns/i) -    183.541M in   5.069987s
+           addition3     36.639M (± 4.8%) i/s   (27.29 ns/i) -    182.994M in   5.009234s
 addition-test-long-label
-                        70.129k i/100ms
--------------------------------------------------
-            addition     4.955M (± 8.7%) i/s -     24.155M
-           addition2    24.011M (± 9.5%) i/s -    114.246M
-           addition3    23.958M (±10.1%) i/s -    115.064M
-addition-test-long-label
-                         5.014M (± 9.1%) i/s -     24.545M
+                         36.164M (± 5.8%) i/s   (27.65 ns/i) -    181.312M in   5.038364s
 
 Comparison:
-           addition2: 24011974.8 i/s
-           addition3: 23958619.8 i/s - 1.00x slower
-addition-test-long-label:  5014756.0 i/s - 4.79x slower
-            addition:  4955278.9 i/s - 4.85x slower
+           addition2: 36558904.5 i/s
+           addition3: 36359284.0 i/s - same-ish: difference falls within error
+addition-test-long-label: 36135428.8 i/s - same-ish: difference falls within error
+            addition: 34666931.3 i/s - same-ish: difference falls within error
 ```
 
 Benchmark/ips will report the number of iterations per second for a given block

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -93,6 +93,19 @@ module Benchmark
         "%10.3f#{suffix}" % scaled_value
       end
       module_function :scale
+
+      def humanize_duration(duration_ns)
+        if duration_ns < 1000
+          "%.2f ns" % duration_ns
+        elsif duration_ns < 1_000_000
+          "%.2f μs" % (duration_ns / 1000)
+        elsif duration_ns < 1_000_000_000
+          "%.2f ms" % (duration_ns / 1_000_000)
+        else
+          "%.2f s" % (duration_ns / 1_000_000_000)
+        end
+      end
+      module_function :humanize_duration
     end
   end
 

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -86,23 +86,25 @@ module Benchmark
         # percentage of standard deviation, iterations in runtime.
         # @return [String] Left justified body.
         def body
+          per_iter = (" (%s/i)" % Helpers.humanize_duration(1_000_000_000 / @stats.central_tendency)).rjust(15)
+
           case Benchmark::IPS.options[:format]
           when :human
-            left = "%s (±%4.1f%%) i/s" % [Helpers.scale(@stats.central_tendency), @stats.error_percentage]
+            left = ("%s (±%4.1f%%) i/s" % [Helpers.scale(@stats.central_tendency), @stats.error_percentage]).ljust(20)
             iters = Helpers.scale(@iterations)
 
             if @show_total_time
-              left.ljust(20) + (" - %s in %10.6fs" % [iters, runtime])
+              left + per_iter + (" - %s in %10.6fs" % [iters, runtime])
             else
-              left.ljust(20) + (" - %s" % iters)
+              left + per_iter + (" - %s" % iters)
             end
           else
-            left = "%10.1f (±%.1f%%) i/s" % [@stats.central_tendency, @stats.error_percentage]
+            left = ("%10.1f (±%.1f%%) i/s" % [@stats.central_tendency, @stats.error_percentage]).ljust(20)
 
             if @show_total_time
-              left.ljust(20) + (" - %10d in %10.6fs" % [@iterations, runtime])
+              left + per_iter + (" - %10d in %10.6fs" % [@iterations, runtime])
             else
-              left.ljust(20) + (" - %10d" % @iterations)
+              left + per_iter + (" - %10d" % @iterations)
             end
           end
         end

--- a/test/test_benchmark_ips.rb
+++ b/test/test_benchmark_ips.rb
@@ -268,4 +268,12 @@ class TestBenchmarkIPS < Minitest::Test
     end
     assert_equal 1, report.entries[0].iterations
   end
+
+  def test_humanize_duration
+    assert_equal Benchmark::IPS::Helpers.humanize_duration(0.000000001), "0.00 ns"
+    assert_equal Benchmark::IPS::Helpers.humanize_duration(123.456789), "123.46 ns"
+    assert_equal Benchmark::IPS::Helpers.humanize_duration(12345.67890123), "12.35 μs"
+    assert_equal Benchmark::IPS::Helpers.humanize_duration(123456789.0123456789), "123.46 ms"
+    assert_equal Benchmark::IPS::Helpers.humanize_duration(123456789012.3456789012), "123.46 s"
+  end
 end


### PR DESCRIPTION
After update, the new report will look like:

```
ruby 3.2.0 (2022-12-25 revision a528908271) +YJIT [arm64-darwin23]
Warming up --------------------------------------
          string.new     1.485M i/100ms
       string.concat     1.086M i/100ms
        string.split   649.289k i/100ms
Calculating -------------------------------------
          string.new     15.947M (± 1.2%) i/s   (62.71 ns/i) -     32.665M in   2.048640s
       string.concat     10.846M (± 0.7%) i/s   (92.20 ns/i) -     21.718M in   2.002441s
        string.split      6.506M (± 0.3%) i/s  (153.70 ns/i) -     13.635M in   2.095740s
```

In some time we need to know how fast (in avg time), the before report only show the iterations/s, but we don't know how long of each iteration. 

So I add the duration of each iteration in the report.

This may be useful to compare the performance with other languages, (e.g. Go, Rust etc.) they have the duration in per iteration.

For example Go:

```
Benchmark_string_alloc-8            	1000000000	         0.3361 ns/op
```

## Use this code to test result:

```rb
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "benchmark-ips", github: "huacnlee/benchmark-ips", branch: "feat/report-duration-per-iter"
end

require "benchmark/ips"

text = "hello world"
part = "world"

Benchmark.ips do |x|
  x.config(time: 2, warmup: 1)

  x.report("string.new") do
    a = "hello world"
  end
  x.report("string.concat") do
    text + part
  end
  x.report("string.split") do
    text.split(" ")
  end
end
```
