### PR TITLE
Make the label column width configurable

### DIFF
--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -69,12 +69,12 @@ module Benchmark
 
       $stdout.puts "\nComparison:"
 
-      $stdout.printf "%20s: %10.1f i/s\n", baseline.label.to_s, baseline.stats.central_tendency
+      $stdout.printf "%s: %10.1f i/s\n", baseline.label.to_s.rjust(IPS.width), baseline.stats.central_tendency
 
       sorted.each do |report|
-        name = report.label.to_s
+        name = report.label.to_s.rjust(IPS.width)
 
-        $stdout.printf "%20s: %10.1f i/s - ", name, report.stats.central_tendency
+        $stdout.printf "%s: %10.1f i/s - ", name, report.stats.central_tendency
 
         if report.stats.overlaps?(baseline.stats)
           $stdout.print "same-ish: difference falls within error"

--- a/lib/benchmark/ips.rb
+++ b/lib/benchmark/ips.rb
@@ -78,7 +78,15 @@ module Benchmark
     #    :human format narrows precision and scales results for readability
     #    :raw format displays 6 places of precision and exact iteration counts
     def self.options
-      @options ||= {:format => :human}
+      @options ||= {
+        :format => :human,
+        :width => 20
+      }
+    end
+
+    # How wide of a column (in characters) to display the labels in (by default 20)
+    def self.width
+      options[:width] || 20
     end
 
     module Helpers
@@ -174,4 +182,12 @@ module Benchmark
   #                 addition:  4955278.9 i/s - 4.85x slower
   #
   # See also Benchmark::IPS
+end
+
+if width = ENV['IPS_WIDTH']
+  w = width.to_i
+
+  if w > 0
+    Benchmark::IPS.options[:width] = w
+  end
 end

--- a/lib/benchmark/ips/job/stream_report.rb
+++ b/lib/benchmark/ips/job/stream_report.rb
@@ -54,10 +54,11 @@ module Benchmark
         # @return [String] Right justified label.
         def rjust(label)
           label = label.to_s
-          if label.size > 20
-            "#{label}\n#{' ' * 20}"
+          width = IPS.width
+          if label.size > width
+            "#{label}\n#{' ' * width}"
           else
-            label.rjust(20)
+            label.rjust(width)
           end
         end
       end

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -86,6 +86,7 @@ module Benchmark
         # percentage of standard deviation, iterations in runtime.
         # @return [String] Left justified body.
         def body
+          width = IPS.width
           per_iter = (" (%s/i)" % Helpers.humanize_duration(1_000_000_000 / @stats.central_tendency)).rjust(15)
 
           case Benchmark::IPS.options[:format]
@@ -99,7 +100,7 @@ module Benchmark
               left + per_iter + (" - %s" % iters)
             end
           else
-            left = ("%10.1f (±%.1f%%) i/s" % [@stats.central_tendency, @stats.error_percentage]).ljust(20)
+            left = ("%10.1f (±%.1f%%) i/s" % [@stats.central_tendency, @stats.error_percentage]).ljust(width)
 
             if @show_total_time
               left + per_iter + (" - %10d in %10.6fs" % [@iterations, runtime])
@@ -109,10 +110,10 @@ module Benchmark
           end
         end
 
-        # Return header with padding if +@label+ is < length of 20.
+        # Return header with padding if +@label+ is < length of the configured width (by default 20).
         # @return [String] Right justified header (+@label+).
         def header
-          @label.to_s.rjust(20)
+          @label.to_s.rjust(IPS.width)
         end
 
         # Return string repesentation of Entry object.


### PR DESCRIPTION
Within the code, `Benchmark::IPS.options[:width] = 40` or via the OS env `IPS_WIDTH=40 ruby my_benchmark.rb`

Closes #131 