### PR TITLE
Declare explicit dependency on `benchmark`

### DIFF
--- a/benchmark-ips.gemspec
+++ b/benchmark-ips.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<minitest>, ["~> 5.4"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
   end
+  s.add_dependency(%q<benchmark>, ["~> 0.1"])
 end


### PR DESCRIPTION
Ruby plans to bundle it: https://github.com/ruby/ruby/pull/11492

That means, in the next ruby version requiring it without it appearing in the gemspec will warn, and the release after that will error.