### PR TITLE
Automatically compute the max label width to always properly align the output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, jruby, truffleruby]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, head, jruby, truffleruby]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/lib/benchmark/compare.rb
+++ b/lib/benchmark/compare.rb
@@ -56,6 +56,8 @@ module Benchmark
     def compare(*entries, order: :fastest)
       return if entries.size < 2
 
+      max_width = entries.map { |e| e.label.to_s.size }.max
+
       case order
       when :baseline
         baseline = entries.shift
@@ -69,12 +71,12 @@ module Benchmark
 
       $stdout.puts "\nComparison:"
 
-      $stdout.printf "%20s: %10.1f i/s\n", baseline.label.to_s, baseline.stats.central_tendency
+      $stdout.printf "%#{max_width}s: %10.1f i/s\n", baseline.label.to_s, baseline.stats.central_tendency
 
       sorted.each do |report|
         name = report.label.to_s
 
-        $stdout.printf "%20s: %10.1f i/s - ", name, report.stats.central_tendency
+        $stdout.printf "%#{max_width}s: %10.1f i/s - ", name, report.stats.central_tendency
 
         if report.stats.overlaps?(baseline.stats)
           $stdout.print "same-ish: difference falls within error"

--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -51,6 +51,10 @@ module Benchmark
       # @return [Integer]
       attr_accessor :confidence
 
+      # The maximum label width
+      # @return [Integer]
+      attr_reader :max_width
+
       # Silence output
       # @return [Boolean]
       def quiet
@@ -72,6 +76,7 @@ module Benchmark
         @compare_order = :fastest
         @held_path = nil
         @held_results = nil
+        @max_width = 20 # automatically computed as entries are added
 
         @timing = Hash.new 1 # default to 1 in case warmup isn't run
         @full_report = Report.new
@@ -85,7 +90,7 @@ module Benchmark
         @stats = :sd
         @confidence = 95
 
-        @out = MultiReport.new(StreamReport.new)
+        @out = MultiReport.new(StreamReport.new(self))
       end
 
       # Job configuration options, set +@warmup+ and +@time+.
@@ -106,7 +111,7 @@ module Benchmark
         if val # remove instances of StreamReport
           @out.quiet!
         else # ensure there is an instance of StreamReport
-          @out << StreamReport.new if @out.quiet?
+          @out << StreamReport.new(self) if @out.quiet?
         end
       end
 
@@ -179,6 +184,8 @@ module Benchmark
 
         action = str || blk
         raise ArgumentError, "no block or string" unless action
+
+        @max_width = label.size if label.size > @max_width
 
         @list.push Entry.new(label, action)
         self

--- a/lib/benchmark/ips/job/stream_report.rb
+++ b/lib/benchmark/ips/job/stream_report.rb
@@ -2,9 +2,10 @@ module Benchmark
   module IPS
     class Job
       class StreamReport
-        def initialize(stream = $stdout)
+        def initialize(job, stream = $stdout)
           @last_item = nil
           @out = stream
+          @job = job
         end
 
         def start_warming
@@ -17,8 +18,9 @@ module Benchmark
         end
 
         def warming(label, _warmup)
-          @out.print rjust(label)
+          @out.print label.to_s.rjust(@job.max_width)
         end
+        alias_method :running, :warming
 
         def warmup_stats(_warmup_time_us, timing)
           case format
@@ -28,8 +30,6 @@ module Benchmark
             @out.printf "%10d i/100ms\n", timing
           end
         end
-
-        alias_method :running, :warming
 
         def add_report(item, caller)
           @out.puts " #{item.body}"
@@ -47,18 +47,6 @@ module Benchmark
         # @return [Symbol] format used for benchmarking
         def format
           Benchmark::IPS.options[:format]
-        end
-
-        # Add padding to label's right if label's length < 20,
-        # Otherwise add a new line and 20 whitespaces.
-        # @return [String] Right justified label.
-        def rjust(label)
-          label = label.to_s
-          if label.size > 20
-            "#{label}\n#{' ' * 20}"
-          else
-            label.rjust(20)
-          end
         end
       end
     end


### PR DESCRIPTION
Using a variant of https://gist.github.com/eregon/27b56c686e238bafa6b46b73f17a4618
(these benchmark results are noisy, don't interpret them, it's just to show output alignment)
Before:
```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
  Prism.parse + walk     2.000 i/100ms
   Parser gem + walk     1.000 i/100ms
   RubyParser + walk     1.000 i/100ms
  Ripper.sexp + walk     1.000 i/100ms
RubyVM::AbstractSyntaxTree + walk
                         2.000 i/100ms
Calculating -------------------------------------
  Prism.parse + walk     22.541 (± 0.0%) i/s   (44.36 ms/i) -    114.000 in   5.058981s
   Parser gem + walk      1.266 (± 0.0%) i/s  (789.94 ms/i) -      7.000 in   5.529701s
   RubyParser + walk      1.172 (± 0.0%) i/s  (853.39 ms/i) -      6.000 in   5.120520s
  Ripper.sexp + walk      9.523 (± 0.0%) i/s  (105.01 ms/i) -     48.000 in   5.047729s
RubyVM::AbstractSyntaxTree + walk
                         21.209 (± 4.7%) i/s   (47.15 ms/i) -    106.000 in   5.003630s

Comparison:
  Prism.parse + walk:       22.5 i/s
RubyVM::AbstractSyntaxTree + walk:       21.2 i/s - 1.06x  slower
  Ripper.sexp + walk:        9.5 i/s - 2.37x  slower
   Parser gem + walk:        1.3 i/s - 17.81x  slower
   RubyParser + walk:        1.2 i/s - 19.24x  slower
```
After:
```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               Prism.parse + walk     2.000 i/100ms
                Parser gem + walk     1.000 i/100ms
                RubyParser + walk     1.000 i/100ms
               Ripper.sexp + walk     1.000 i/100ms
RubyVM::AbstractSyntaxTree + walk     2.000 i/100ms
Calculating -------------------------------------
               Prism.parse + walk     22.261 (± 0.0%) i/s   (44.92 ms/i) -    112.000 in   5.033290s
                Parser gem + walk      1.242 (± 0.0%) i/s  (804.86 ms/i) -      7.000 in   5.636524s
                RubyParser + walk      1.156 (± 0.0%) i/s  (864.95 ms/i) -      6.000 in   5.189805s
               Ripper.sexp + walk      9.373 (± 0.0%) i/s  (106.69 ms/i) -     47.000 in   5.023535s
RubyVM::AbstractSyntaxTree + walk     21.235 (± 4.7%) i/s   (47.09 ms/i) -    108.000 in   5.090632s

Comparison:
               Prism.parse + walk:       22.3 i/s
RubyVM::AbstractSyntaxTree + walk:       21.2 i/s - 1.05x  slower
               Ripper.sexp + walk:        9.4 i/s - 2.37x  slower
                Parser gem + walk:        1.2 i/s - 17.92x  slower
                RubyParser + walk:        1.2 i/s - 19.25x  slower
```

Notably for the Comparison it looked not nice, and for warmup and calculating it kind of broke the flow by having extra newlines.

FWIW this is part of the benchmarks I ran for https://eregon.me/blog/2024/10/27/benchmarking-ruby-parsers.html