### PR TITLE
Use a json content type to submit the report

### DIFF
--- a/lib/benchmark/ips/share.rb
+++ b/lib/benchmark/ips/share.rb
@@ -15,7 +15,7 @@ module Benchmark
         base = (ENV['SHARE_URL'] || DEFAULT_URL)
         url = URI(File.join(base, "reports"))
 
-        req = Net::HTTP::Post.new(url)
+        req = Net::HTTP::Post.new(url, initheader = {'Content-Type' =>'application/json'})
 
         data = {
           "entries" => @report.data,


### PR DESCRIPTION
When sharing the benchmark report to benchmark.fyi, we can set the content type to `application/json` so it's parsed properly by Rails.

For more context, we have to handle the body in a non-standard way manually parsing the request body when the content_type is not specified, something discussed in https://github.com/fastruby/benchmark.fyi/pull/15