### PR TITLE
Use harmonic mean to calculate IPS

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -227,7 +227,7 @@ module Benchmark
         JSON.load(IO.read(@held_path)).each do |result|
           @held_results[result['item']] = result
           create_report(result['item'], result['measured_us'], result['iter'],
-                        create_stats(result['samples']), result['cycles'])
+                        create_stats(result['samples'], result['measured_us'], result['iter']), result['cycles'])
         end
       end
 
@@ -359,7 +359,7 @@ module Benchmark
             iterations_per_sec cycles, time_us
           }
 
-          rep = create_report(item.label, measured_us, iter, create_stats(samples), cycles)
+          rep = create_report(item.label, measured_us, iter, create_stats(samples, measured_us, iter), cycles)
 
           if (final_time - target).abs >= (@time.to_f * MAX_TIME_SKEW)
             rep.show_total_time!
@@ -371,10 +371,10 @@ module Benchmark
         end
       end
 
-      def create_stats(samples)
+      def create_stats(samples, measured_us, iterations)
         case @stats
           when :sd
-            Stats::SD.new(samples)
+            Stats::SD.new(samples, measured_us, iterations)
           when :bootstrap
             Stats::Bootstrap.new(samples, @confidence)
           else

--- a/lib/benchmark/ips/report.rb
+++ b/lib/benchmark/ips/report.rb
@@ -90,7 +90,15 @@ module Benchmark
 
           case Benchmark::IPS.options[:format]
           when :human
-            left = ("%s (±%4.1f%%) i/s" % [Helpers.scale(@stats.central_tendency), @stats.error_percentage]).ljust(20)
+            central_tendency = Helpers.scale(@stats.central_tendency)
+            error_percentage = @stats.error_percentage
+            left =
+              if error_percentage > 99.9
+                "%s (± Inf%%) i/s" % [central_tendency]
+              else
+                "%s (±%4.1f%%) i/s" % [central_tendency, @stats.error_percentage]
+              end.ljust(20)
+
             iters = Helpers.scale(@iterations)
 
             if @show_total_time

--- a/lib/benchmark/ips/stats/sd.rb
+++ b/lib/benchmark/ips/stats/sd.rb
@@ -8,7 +8,7 @@ module Benchmark
 
         def initialize(samples)
           @samples = samples
-          @mean = Timing.mean(samples)
+          @mean = Timing.harmonic_mean(samples)
           @error = Timing.stddev(samples, @mean).round
         end
 

--- a/lib/benchmark/ips/stats/sd.rb
+++ b/lib/benchmark/ips/stats/sd.rb
@@ -6,9 +6,9 @@ module Benchmark
         include StatsMetric
         attr_reader :error, :samples
 
-        def initialize(samples)
+        def initialize(samples, measured_us, iterations)
           @samples = samples
-          @mean = Timing.harmonic_mean(samples)
+          @mean = Timing::MICROSECONDS_PER_SECOND * (iterations.to_f / measured_us)
           @error = Timing.stddev(samples, @mean).round
         end
 

--- a/lib/benchmark/timing.rb
+++ b/lib/benchmark/timing.rb
@@ -12,14 +12,6 @@ module Benchmark
       sum / samples.size
     end
 
-    # Calculate harmonic mean of given samples.
-    # @param [Array] samples Samples to calculate mean.
-    # @return [Float] Harmonic mean of given samples.
-    def self.harmonic_mean(samples)
-      reciprocals = samples.inject(0) { |acc, i| acc + (1.0 / i) }
-      samples.size / reciprocals
-    end
-
     # Calculate variance of given samples.
     # @param [Float] m Optional mean (Expected value).
     # @return [Float] Variance of given samples.

--- a/lib/benchmark/timing.rb
+++ b/lib/benchmark/timing.rb
@@ -4,12 +4,20 @@ module Benchmark
     # Microseconds per second.
     MICROSECONDS_PER_SECOND = 1_000_000
 
-    # Calculate (arithmetic) mean of given samples.
+    # Calculate arithmetic mean of given numbers.
     # @param [Array] samples Samples to calculate mean.
-    # @return [Float] Mean of given samples.
+    # @return [Float] Mean of given numbers.
     def self.mean(samples)
       sum = samples.inject(:+)
       sum / samples.size
+    end
+
+    # Calculate harmonic mean of given samples.
+    # @param [Array] samples Samples to calculate mean.
+    # @return [Float] Harmonic mean of given samples.
+    def self.harmonic_mean(samples)
+      reciprocals = samples.inject(0) { |acc, i| acc + (1.0 / i) }
+      samples.size / reciprocals
     end
 
     # Calculate variance of given samples.


### PR DESCRIPTION
We pass an array of "samples" to `Stats::SD`. Previously an arithmetic mean was used on those samples. Because these are rates (instructions per second), we should use a harmonic mean instead.

That's a little abstract for me so here's an example:

``` ruby
require "benchmark/ips"

i = 0
Benchmark.ips do |x|
  x.report "100 ips" do
    sleep 1 if i % 100 == 0
    i += 1
  end

  x.report "1000 ips" do
    sleep 0.001
    i += 1
  end
end
```

The first benchmark has a high variance, 1/100 iterations takes 1 second, otherwise it's nearly instant. I think everyone would agree that's 100 i/s. The second has consistent timing, and every iteration takes 1ms. I think everyone would agree that's 1000 i/s.

However when using the arithmetic mean, we're incorrectly biased towards the fast measurements.

Before (arithmetic mean):

    ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]
    Warming up --------------------------------------
                 100 ips     1.000 i/100ms
                1000 ips    95.000 i/100ms
    Calculating -------------------------------------
                 100 ips      5.826M (±16.8%) i/s  (171.64 ns/i) -    459.000 in   5.000456s
                1000 ips    949.996 (± 0.0%) i/s    (1.05 ms/i) -      4.750k in   5.000024s

After (harmonic mean):

    ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]
    Warming up --------------------------------------
                 100 ips     1.000 i/100ms
                1000 ips    95.000 i/100ms
    Calculating -------------------------------------
                 100 ips     91.778 (±6617320.3%) i/s   (10.90 ms/i) -    459.000 in   5.001200s
                1000 ips    950.020 (± 0.0%) i/s    (1.05 ms/i) -      4.845k in   5.099893s

This does make the stats calculation essentially a complicated way to calculate total_iterations / total_time, which is the correct overall rate.